### PR TITLE
Adds error state for TextInput

### DIFF
--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -1,5 +1,5 @@
 import '../scss/text-input.scss';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 function TextInput({
@@ -12,17 +12,25 @@ function TextInput({
   errorMessage,
 }) {
   const [inputValue, setInputValue] = useState(value);
+  const inputRef = useRef(null);
 
   const onInputChange = event => {
     setInputValue(event.target.value);
     onChange(event.target.value);
   };
 
+  useEffect(() => {
+    // Toggles the :invalid pseudo-class on the input. Setting an
+    // empty string removes the pseudo-class
+    inputRef.current.setCustomValidity(error ? errorMessage : '');
+  }, [error]);
+
   return (
     <div className={`text-input-container ${className}`}>
       <input
+        ref={inputRef}
         type={type}
-        className={`text-input ${error ? 'has-error' : ''}`}
+        className="text-input"
         placeholder={placeHolder}
         onChange={onInputChange}
         value={inputValue}

--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -19,10 +19,10 @@ function TextInput({
   };
 
   return (
-    <div className="text-input-container">
+    <div className={`text-input-container ${className}`}>
       <input
         type={type}
-        className={`text-input ${className} ${error ? 'has-error' : ''}`}
+        className={`text-input ${error ? 'has-error' : ''}`}
         placeholder={placeHolder}
         onChange={onInputChange}
         value={inputValue}

--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -8,6 +8,8 @@ function TextInput({
   type,
   value,
   onChange,
+  error,
+  errorMessage,
 }) {
   const [inputValue, setInputValue] = useState(value);
 
@@ -17,13 +19,18 @@ function TextInput({
   };
 
   return (
-    <input
-      type={type}
-      className={`text-input ${className}`}
-      placeholder={placeHolder}
-      onChange={onInputChange}
-      value={inputValue}
-    />
+    <div className="text-input-container">
+      <input
+        type={type}
+        className={`text-input ${className} ${error ? 'has-error' : ''}`}
+        placeholder={placeHolder}
+        onChange={onInputChange}
+        value={inputValue}
+      />
+      {errorMessage && error && (
+        <p className="text-input-error">{errorMessage}</p>
+      )}
+    </div>
   );
 }
 
@@ -33,14 +40,22 @@ TextInput.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
   type: PropTypes.oneOf(['email', 'password', 'text']),
+  error: PropTypes.bool,
+  errorMessage: PropTypes.string,
 };
 
 TextInput.defaultProps = {
   className: '',
   placeHolder: '',
   value: '',
-  onChange: () => {},
+  /**
+   * @param {string} text The current input value
+   */
+  // eslint-disable-next-line no-unused-vars
+  onChange: text => {},
   type: 'text',
+  error: false,
+  errorMessage: '',
 };
 
 export default TextInput;

--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -1,5 +1,5 @@
 import '../scss/text-input.scss';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 function TextInput({
@@ -8,34 +8,27 @@ function TextInput({
   type,
   value,
   onChange,
-  error,
   errorMessage,
 }) {
   const [inputValue, setInputValue] = useState(value);
-  const inputRef = useRef(null);
+  const [valid, setValidity] = useState(true);
 
   const onInputChange = event => {
+    setValidity(event.target.validity.valid);
     setInputValue(event.target.value);
     onChange(event.target.value);
   };
 
-  useEffect(() => {
-    // Toggles the :invalid pseudo-class on the input. Setting an
-    // empty string removes the pseudo-class
-    inputRef.current.setCustomValidity(error ? errorMessage : '');
-  }, [error]);
-
   return (
     <div className={`text-input-container ${className}`}>
       <input
-        ref={inputRef}
         type={type}
         className="text-input"
         placeholder={placeHolder}
         onChange={onInputChange}
         value={inputValue}
       />
-      {errorMessage && error && (
+      {errorMessage && !valid && (
         <p className="text-input-error">{errorMessage}</p>
       )}
     </div>

--- a/src/components/TextInput.jsx
+++ b/src/components/TextInput.jsx
@@ -48,11 +48,7 @@ TextInput.defaultProps = {
   className: '',
   placeHolder: '',
   value: '',
-  /**
-   * @param {string} text The current input value
-   */
-  // eslint-disable-next-line no-unused-vars
-  onChange: text => {},
+  onChange: () => {},
   type: 'text',
   error: false,
   errorMessage: '',

--- a/src/scss/text-input.scss
+++ b/src/scss/text-input.scss
@@ -1,18 +1,34 @@
 @import 'variables';
 
-.text-input {
-  font-size: 16px;
-  padding: 10px 14px;
-  border-radius: 6px;
-  border: 1px solid #aaaaaa;
-  transition: border-color 0.2s ease-in-out;
+.text-input-container {
   width: 100%;
-  box-sizing: border-box;
-  // Removes the inner box shadow in Safari
-  appearance: none;
 
-  &:focus {
-    outline: none;
-    border-color: lighten(map-get($variant-colors, 'primary'), 20%);
+  .text-input {
+    font-size: 16px;
+    padding: 10px 14px;
+    border-radius: 6px;
+    border: 1px solid #aaaaaa;
+    transition: border-color 0.2s ease-in-out;
+    width: 100%;
+    box-sizing: border-box;
+    // Removes the inner box shadow in Safari
+    appearance: none;
+
+    &.has-error,
+    &.has-error:focus {
+      border-color: map-get($variant-colors, 'danger');
+    }
+
+    &:focus {
+      outline: none;
+      border-color: lighten(map-get($variant-colors, 'primary'), 20%);
+    }
+  }
+
+  .text-input-error {
+    font-size: 15px;
+    margin: 8px 0 0 6px;
+    text-align: left;
+    color: map-get($variant-colors, 'danger');
   }
 }

--- a/src/scss/text-input.scss
+++ b/src/scss/text-input.scss
@@ -27,7 +27,7 @@
 
   .text-input-error {
     font-size: 15px;
-    margin: 8px 0 0 6px;
+    margin: 8px 0 8px 6px;
     text-align: left;
     color: map-get($variant-colors, 'danger');
   }

--- a/src/scss/text-input.scss
+++ b/src/scss/text-input.scss
@@ -7,20 +7,22 @@
     font-size: 16px;
     padding: 10px 14px;
     border-radius: 6px;
-    border: 1px solid #aaaaaa;
+    border: 1px solid hsl(0, 0%, 76%);
     transition: border-color 0.2s ease-in-out;
     width: 100%;
     box-sizing: border-box;
     // Removes the inner box shadow in Safari
     appearance: none;
 
-    &.has-error,
-    &.has-error:focus {
+    &:focus {
+      outline: none;
+    }
+
+    &:invalid {
       border-color: map-get($variant-colors, 'danger');
     }
 
-    &:focus {
-      outline: none;
+    &:focus:not(:invalid) {
       border-color: lighten(map-get($variant-colors, 'primary'), 20%);
     }
   }


### PR DESCRIPTION
Adds an `error` prop along with an `errorMessage` prop that displays the error text underneath the `TextInput`.

Fixes #17 