### PR TITLE
Add group list component

### DIFF
--- a/src/components/dashboard/GroupList.jsx
+++ b/src/components/dashboard/GroupList.jsx
@@ -1,0 +1,64 @@
+import '../../scss/group-list.scss';
+import React from 'react';
+import { Avatar, List } from 'antd';
+import PropTypes from 'prop-types';
+
+function GroupList({ groups, onGroupClick }) {
+  const getMemberText = members => {
+    if (members === 1) {
+      return `${members} member`;
+    }
+
+    return `${members} members`;
+  };
+
+  const renderGroupImage = (imageURL, title) => (
+    <Avatar src={imageURL} size={54} alt={title}>
+      {title[0]}
+    </Avatar>
+  );
+
+  const renderListItem = ({ title, imageURL, members }, index) => (
+    <List.Item onClick={() => onGroupClick(groups[index])} title={title}>
+      <List.Item.Meta
+        avatar={renderGroupImage(imageURL, title)}
+        title={title}
+        description={getMemberText(members)}
+      />
+    </List.Item>
+  );
+
+  return (
+    <div className="group-list">
+      <List
+        dataSource={groups}
+        header={<p className="list-header">Your Groups</p>}
+        locale={{
+          emptyText: `
+            Looks like you’re not a member of any groups yet. Click the
+            "Create Group" button to create a new group or click the
+            "Join Group" button to join a group.
+          `,
+        }}
+        renderItem={renderListItem}
+      />
+    </div>
+  );
+}
+
+GroupList.propTypes = {
+  groups: PropTypes.arrayOf(
+    PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      imageURL: PropTypes.string,
+      members: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+  onGroupClick: PropTypes.func,
+};
+
+GroupList.defaultProps = {
+  onGroupClick: () => {},
+};
+
+export default GroupList;

--- a/src/components/dashboard/JoinGroupButton.jsx
+++ b/src/components/dashboard/JoinGroupButton.jsx
@@ -51,6 +51,7 @@ function JoinGroupButton() {
     <div className='center'>
       <Button className='joinButton' onClick={showModal}>Join Group</Button>
       <Modal
+        centered
         title='Join group'
         visible={visible}
         onOk={submitCode}

--- a/src/components/dashboard/Sidebar.jsx
+++ b/src/components/dashboard/Sidebar.jsx
@@ -3,14 +3,47 @@ import React from 'react';
 import { Layout } from 'antd';
 import Card from '../Card.jsx';
 import InviteArea from './InviteArea.jsx';
+import GroupList from './GroupList.jsx';
 
 const { Sider } = Layout;
+
+const groups = [
+  {
+    title: 'Group TBA',
+    imageURL: null,
+    members: 103,
+  },
+  {
+    title: 'Socks n Sandals',
+    imageURL:
+      'https://images.unsplash.com/photo-1617450599731-0ec86e189589?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1950&q=80',
+    members: 592,
+  },
+  {
+    title: 'Architecture',
+    imageURL:
+      'https://images.unsplash.com/photo-1617538781052-b49b1bc7cbe1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1866&q=80',
+    members: 900,
+  },
+  {
+    title: 'JavaScript Junkies',
+    imageURL:
+      'https://images.unsplash.com/photo-1617541224621-c6dbd1bb5bbb?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=2100&q=80',
+    members: 1,
+  },
+  {
+    title: 'This is a group with a title that should show ellipses',
+    imageURL: 'https://unsplash.com/photos/IGfIGP5ONV0',
+    members: 420,
+  },
+];
 
 function Sidebar() {
   return (
     <Sider theme="light" className="sidebar">
       <Card className="sidebar-card">
         <InviteArea inviteCode="xJwY394p" />
+        <GroupList groups={groups} />
       </Card>
     </Sider>
   );

--- a/src/components/dashboard/Sidebar.jsx
+++ b/src/components/dashboard/Sidebar.jsx
@@ -10,6 +10,7 @@ import CreateGroupModal from '../CreateGroupModal.jsx';
 
 const { Sider } = Layout;
 
+// eslint-disable-next-line no-unused-vars
 const groups = [
   {
     title: 'Group TBA',
@@ -52,8 +53,10 @@ function Sidebar() {
       <Card className="sidebar-card">
         <InviteArea inviteCode="xJwY394p" />
         <GroupList groups={groups} />
-        <JoinGroupButton />
-        <Button onClick={openGroupModal}>Create Group</Button>
+        <div className="sidebar-actions">
+          <JoinGroupButton />
+          <Button onClick={openGroupModal}>Create Group</Button>
+        </div>
         <CreateGroupModal
           visible={isGroupModalVisible}
           onClose={closeGroupModal}

--- a/src/components/dashboard/Sidebar.jsx
+++ b/src/components/dashboard/Sidebar.jsx
@@ -33,7 +33,7 @@ const groups = [
   },
   {
     title: 'This is a group with a title that should show ellipses',
-    imageURL: 'https://unsplash.com/photos/IGfIGP5ONV0',
+    imageURL: 'bad-url',
     members: 420,
   },
 ];

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -4,7 +4,6 @@ import 'antd/dist/antd.css';
 import React from 'react';
 import { Button } from 'antd';
 import { BsThreeDots } from 'react-icons/bs';
-import { motion } from 'framer-motion';
 import Navbar from '../components/dashboard/Navbar.jsx';
 import Sidebar from '../components/dashboard/Sidebar.jsx';
 import PhotoGrid from '../components/dashboard/PhotoGrid.jsx';
@@ -31,41 +30,41 @@ const photos = [
 
 function MainPage() {
   return (
-    <motion.div
-      initial={{ scale: 0.5, opacity: 1 }}
-      animate={{ scale: 1, opacity: 1 }}
-      exit={{
-        scale: 0.5,
-        opacity: 0,
-        transition: { duration: 1.5 },
-      }}
-      transition={{ duration: 2, type: 'spring' }}
-    >
-      <div className="main-page-body">
-        <Navbar />
-        <div className="body-content">
-          <Sidebar />
-          <div className="main-content">
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-              <h1>Group Name</h1>
-              <Button
-                type="primary"
-                size="large"
-                shape="circle"
-                style={{
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                }}
-              >
-                <BsThreeDots />
-              </Button>
-            </div>
-            <PhotoGrid photos={photos} />
+    // <motion.div
+    //   initial={{ scale: 0.5, opacity: 1 }}
+    //   animate={{ scale: 1, opacity: 1 }}
+    //   exit={{
+    //     scale: 0.5,
+    //     opacity: 0,
+    //     transition: { duration: 1.5 },
+    //   }}
+    //   transition={{ duration: 2, type: 'spring' }}
+    // >
+    <div className="main-page-body">
+      <Navbar />
+      <div className="body-content">
+        <Sidebar />
+        <div className="main-content">
+          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <h1>Group Name</h1>
+            <Button
+              type="primary"
+              size="large"
+              shape="circle"
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <BsThreeDots />
+            </Button>
           </div>
+          <PhotoGrid photos={photos} />
         </div>
       </div>
-    </motion.div>
+    </div>
+    // </motion.div>
   );
 }
 

--- a/src/scss/ant-overrides.scss
+++ b/src/scss/ant-overrides.scss
@@ -20,10 +20,27 @@
 }
 
 .ant-modal-footer {
+  $primary: map-get($variant-colors, 'primary');
   border-top: none;
   padding-top: 0;
   padding-bottom: 24px;
+
+  // Overrides the color of the cancel button on hover
+  // in ant's modal footers
+  .ant-btn:hover:not(.ant-btn-primary):not(:disabled) {
+    border-color: $primary;
+    color: $primary;
+  }
+
+  // Overrides the color of the primary action button
+  // in ant's modal footers to match the color of our
+  // custom buttons
+  .ant-btn.ant-btn-primary:not(:disabled) {
+    background-color: lighten(rgba($primary, 0.2), 35%);
+    color: $primary;
+  }
 }
+
 
 .ant-modal-footer {
   border-top: none;
@@ -76,6 +93,7 @@
   }
 
   &:focus {
+    box-shadow: none;
     border-color: lighten(map-get($variant-colors, 'primary'), 20%);
   }
 }
@@ -89,4 +107,15 @@ span.anticon.anticon-delete {
 // Overrides the font size for ant's <Checkbox /> component
 .ant-checkbox-wrapper span {
   font-size: 16px;
+}
+
+// Overrides the title of ant's notification message
+.ant-notification-notice-message {
+  font-weight: 600;
+}
+
+// Overrides the body of ant's notification message
+.ant-notification-notice-description {
+  font-family: 'DM Sans', Arial, Helvetica, sans-serif;
+  font-size: 16px !important;
 }

--- a/src/scss/button.scss
+++ b/src/scss/button.scss
@@ -20,6 +20,10 @@
   text-decoration: none;
   border: none;
   cursor: pointer;
+
+  &:focus {
+    outline: none;
+  }
 }
 
 // Iterate over the color map and construct variants from it's keys and values.

--- a/src/scss/group-list.scss
+++ b/src/scss/group-list.scss
@@ -1,0 +1,54 @@
+@import 'variables';
+
+.group-list {
+  font-family: 'DM Sans', Arial, Helvetica, sans-serif;
+
+  .ant-list-item {
+    border-bottom: none;
+    cursor: pointer;
+  }
+
+  .ant-list-item-meta-content * {
+    font-size: 16px;
+  }
+
+  .ant-list-item-meta-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .ant-list-item-meta-description {
+    color: hsl(0, 0%, 40%);
+    font-size: 14px;
+  }
+
+  .ant-list-empty-text {
+    color: hsl(0, 0%, 40%);
+    font-size: 15px;
+    text-align: left;
+    padding: 0;
+  }
+
+  .ant-avatar {
+    border-radius: 10px;
+    background-color: white;
+    text-transform: uppercase;
+    font-size: 16px;
+    color: darken(map-get($variant-colors, 'primary'), 10%);
+    background-color: lighten(map-get($variant-colors, 'primary'), 58%);
+    font-weight: 700;
+  }
+
+  .ant-list-header {
+    border: none;
+  }
+
+  .list-header {
+    margin: 0;
+    padding: 0;
+    font-weight: 600;
+    font-size: 16px;
+    font-family: 'Poppins', Arial, Helvetica, sans-serif;
+  }
+}

--- a/src/scss/group-list.scss
+++ b/src/scss/group-list.scss
@@ -33,11 +33,14 @@
   .ant-avatar {
     border-radius: 10px;
     background-color: white;
-    text-transform: uppercase;
-    font-size: 16px;
     color: darken(map-get($variant-colors, 'primary'), 10%);
     background-color: lighten(map-get($variant-colors, 'primary'), 58%);
-    font-weight: 700;
+
+    .ant-avatar-string {
+      font-size: 20px;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
   }
 
   .ant-list-header {

--- a/src/scss/join-group-button.scss
+++ b/src/scss/join-group-button.scss
@@ -1,5 +1,4 @@
 .center {
-  margin: 10px 0;
   text-align: center;
 }
 

--- a/src/scss/photo-grid.scss
+++ b/src/scss/photo-grid.scss
@@ -21,9 +21,12 @@
 }
 
 .ant-image:hover {
-    box-shadow: map-get($map: $box-shadows, $key: 'md');
     transition: 400ms;
     background-color: transparent !important;
+    
+    img {
+        box-shadow: map-get($map: $box-shadows, $key: 'md');
+    }
 }
 
 .ant-image-mask {

--- a/src/scss/sidebar.scss
+++ b/src/scss/sidebar.scss
@@ -27,4 +27,15 @@ aside.sidebar {
     flex-direction: column;
     padding: 24px;
   }
+
+  .sidebar-actions {
+    margin-top: 16px;
+
+    button {
+      width: 100%;
+      padding-top: 7px;
+      padding-bottom: 7px;
+      margin: 5px 0;
+    }
+  }
 }

--- a/src/scss/sidebar.scss
+++ b/src/scss/sidebar.scss
@@ -26,6 +26,7 @@ aside.sidebar {
     overflow: auto;
     flex-direction: column;
     padding: 24px;
+    margin: 0;
   }
 
   .sidebar-actions {


### PR DESCRIPTION
Adds a list of groups to the sidebar along with some small style changes:
- The sidebar is now a little bit wider (removed the `2.5%` margin)
- The buttons in ant's modals matches the theme of ours
- The Join Group modal is centered
- The title of ant's notification uses `Poppins` while the body uses `DM Sans`
- The box-shadow that appears when you hover over an image on the image grid is applied to the image instead of the container
- Temporarily removed the initial scale animation for the main page when it mounts