### PR TITLE
Adds email verification skeleton

### DIFF
--- a/src/api/API.js
+++ b/src/api/API.js
@@ -93,6 +93,24 @@ const API = {
     await new Promise(resolve => setTimeout(resolve, 3000));
     return true;
   },
+
+  /**
+   * Verifies a users email. The verification code should match
+   * the code sent from the API.
+   *
+   * @param {string} userId
+   * @param {string} verificationCode
+   * @throws {APIError} On server error
+   * @returns {Promise<UserResponse>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  verifyEmail: async (userId, verificationCode) => {
+    // TODO: Implement this
+    // Debug code to wait a few seconds before resolving
+    // (for testing only)
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    return true;
+  },
 };
 
 export default API;

--- a/src/api/API.js
+++ b/src/api/API.js
@@ -57,6 +57,23 @@ const API = {
    */
   register: async (payload) => fetch(relURL('/users/'), postOptions(payload))
     .then(handleResponse),
+
+  /**
+   * Takes an email address and makes a request to send
+   * a verification link to that email.
+   *
+   * @param {string} email
+   * @throws {APIError} On server error
+   * @returns {Promise<UserResponse>}
+   */
+  // eslint-disable-next-line no-unused-vars
+  requestEmailVerificationLink: async email => {
+    // TODO: Implement this
+    // Debug code to wait a few seconds before resolving
+    // (for testing only)
+    await new Promise(resolve => setTimeout(resolve, 3000));
+    return true;
+  },
 };
 
 export default API;

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -8,12 +8,16 @@ function Button({
   children,
   onClick,
   type,
+  disabled,
 }) {
+  const noop = () => {};
+
   return (
     <button
-      onClick={onClick}
+      onClick={disabled ? noop : onClick}
       type={type}
       className={`btn btn-${variant} ${className}`}
+      disabled={disabled}
     >
       {children}
     </button>
@@ -26,6 +30,7 @@ Button.defaultProps = {
   onClick: () => {},
   className: '',
   type: 'button',
+  disabled: false,
 };
 
 Button.propTypes = {
@@ -34,6 +39,7 @@ Button.propTypes = {
   onClick: PropTypes.func,
   className: PropTypes.string,
   type: PropTypes.oneOf(['button', 'submit', 'reset']),
+  disabled: PropTypes.bool,
 };
 
 export default Button;

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -17,7 +17,7 @@ function Card({ className, children }) {
 
 Card.propTypes = {
   className: PropTypes.string,
-  children: PropTypes.element,
+  children: PropTypes.node,
 };
 
 Card.defaultProps = {

--- a/src/components/landing/LoginCard.jsx
+++ b/src/components/landing/LoginCard.jsx
@@ -1,7 +1,8 @@
+/* eslint-disable no-unused-vars */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
-import { Divider } from 'antd';
+import { Divider, message, Modal } from 'antd';
 import LandingCard from './LandingCard.jsx';
 import TextInput from '../TextInput.jsx';
 import Button from '../Button.jsx';
@@ -11,20 +12,46 @@ import API from '../../api/API';
 function LoginCard({ switchCard }) {
   const history = useHistory();
   const [err, setError] = useState(null);
+  const [isModalVisible, setModalVisible] = useState(false);
+  const [isLoading, setLoading] = useState(false);
 
   async function onSubmit(event) {
     event.preventDefault();
+
+    if (isLoading) {
+      return;
+    }
+
+    setLoading(true);
     const data = new FormData(event.target);
 
     try {
       await API.login(data.get('Username'), data.get('Password'));
     } catch (e) {
-      setError(e.message);
+      // setError(e.message);
+      // TODO: Handle email verification error here, this is for testing the modal
+      setModalVisible(true);
+      setLoading(false);
       return;
     }
 
     // Move to next page
     history.push('/main');
+  }
+
+  async function resendEmail() {
+    setLoading(true);
+
+    try {
+      // TODO: Make request
+      await API.requestEmailVerificationLink('test@example.com');
+      message.success('An email was sent to your inbox');
+      setModalVisible(false);
+    } catch (e) {
+      setError(e);
+    }
+
+    setLoading(false);
   }
 
   return (
@@ -34,11 +61,37 @@ function LoginCard({ switchCard }) {
           <TextInput placeHolder="Username" name="Username" />
           <TextInput placeHolder="Password" name="Password" type="password" />
         </div>
-        <Button type="submit">Login</Button>
-        <Button className="btn-link" onClick={() => switchCard('forgotPassword')}>Forgot password?</Button>
+        <Button type="submit" disabled={isLoading}>Login</Button>
+        <Button
+          className="btn-link"
+          onClick={() => switchCard('forgotPassword')}
+        >
+          Forgot password?
+        </Button>
         <Divider>OR</Divider>
-        <Button className="btn-link" onClick={() => switchCard('register')}>Don&apos;t have an Account?</Button>
+        <Button className="btn-link" onClick={() => switchCard('register')}>
+          Don&apos;t have an account?
+        </Button>
       </form>
+      <Modal
+        centered
+        title="Verify Your Email"
+        okText={isLoading ? 'Sending' : 'Resend'}
+        cancelText="Close"
+        visible={isModalVisible}
+        okButtonProps={{
+          loading: isLoading,
+          disabled: isLoading,
+        }}
+        onOk={resendEmail}
+        onCancel={() => setModalVisible(false)}
+      >
+        <span>
+          Looks like you haven&apos;t verified your email yet. Check your inbox
+          or click resend if you didn&apos;t receive an email, then try logging
+          in again.
+        </span>
+      </Modal>
     </LandingCard>
   );
 }

--- a/src/components/landing/LoginCard.jsx
+++ b/src/components/landing/LoginCard.jsx
@@ -61,7 +61,9 @@ function LoginCard({ switchCard }) {
           <TextInput placeHolder="Username" name="Username" />
           <TextInput placeHolder="Password" name="Password" type="password" />
         </div>
-        <Button type="submit" disabled={isLoading}>Login</Button>
+        <Button type="submit" disabled={isLoading}>
+          Login
+        </Button>
         <Button
           className="btn-link"
           onClick={() => switchCard('forgotPassword')}
@@ -76,6 +78,7 @@ function LoginCard({ switchCard }) {
       <Modal
         centered
         title="Verify Your Email"
+        className="verify-email-modal"
         okText={isLoading ? 'Sending' : 'Resend'}
         cancelText="Close"
         visible={isModalVisible}
@@ -86,11 +89,11 @@ function LoginCard({ switchCard }) {
         onOk={resendEmail}
         onCancel={() => setModalVisible(false)}
       >
-        <span>
+        <p className="modal-body">
           Looks like you haven&apos;t verified your email yet. Check your inbox
           or click resend if you didn&apos;t receive an email, then try logging
           in again.
-        </span>
+        </p>
       </Modal>
     </LandingCard>
   );

--- a/src/components/landing/RegisterCard.jsx
+++ b/src/components/landing/RegisterCard.jsx
@@ -1,6 +1,4 @@
-/* eslint-disable no-unused-vars */
 import React, { useState } from 'react';
-import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { Alert, message } from 'antd';
 import LandingCard from './LandingCard.jsx';
@@ -9,10 +7,10 @@ import Button from '../Button.jsx';
 import API from '../../api/API';
 
 function RegisterCard({ switchCard }) {
-  const history = useHistory();
   const [err, setError] = useState(null);
   const [isRegistered, setRegistered] = useState(false);
   const [isLoading, setLoading] = useState(false);
+  const [userEmail, setUserEmail] = useState('');
 
   function isTrimmedEmpty(str) {
     if (str.trim() === '') return true;
@@ -40,14 +38,16 @@ function RegisterCard({ switchCard }) {
       if (isTrimmedEmpty(data.password)) throw (new Error('Password input required.'));
       if (isTrimmedEmpty(data.confirmPassword)) throw (new Error('Confirm password input required.'));
 
+      setUserEmail(data.email);
+
       // Calling register API
-      // await API.register({
-      //   firstName: data.firstName,
-      //   lastName: data.lastName,
-      //   email: data.email,
-      //   username: data.username,
-      //   password: data.password,
-      // });
+      await API.register({
+        firstName: data.firstName,
+        lastName: data.lastName,
+        email: data.email,
+        username: data.username,
+        password: data.password,
+      });
     } catch (e) {
       setError(e.message);
       setLoading(false);
@@ -64,7 +64,7 @@ function RegisterCard({ switchCard }) {
 
     try {
       // TODO: Make request
-      await API.requestEmailVerificationLink('test@example.com');
+      await API.requestEmailVerificationLink(userEmail);
       message.success('An email was sent to your inbox');
     } catch (e) {
       setError(e);
@@ -73,7 +73,7 @@ function RegisterCard({ switchCard }) {
     setLoading(false);
   };
 
-  const renderForm = () => (
+  const registerForm = (
     <form onSubmit={onSubmit}>
       <div className="input-group">
         <TextInput placeHolder="First name" name="firstName" required />
@@ -102,11 +102,11 @@ function RegisterCard({ switchCard }) {
     </form>
   );
 
-  const renderSuccessMessage = () => (
+  const successMessage = (
     <div className="form-area-success">
       <Alert
         type="success"
-        message="Account created!"
+        message="Account Created!"
         description={`
           A verification email was sent to your inbox.
           Click the link to verify your email before
@@ -125,7 +125,7 @@ function RegisterCard({ switchCard }) {
 
   return (
     <LandingCard title="Register" error={err}>
-      {isRegistered ? renderSuccessMessage() : renderForm()}
+      {isRegistered ? successMessage : registerForm}
     </LandingCard>
   );
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,6 +9,7 @@ import reportWebVitals from './reportWebVitals';
 import 'antd/dist/antd.css';
 import './scss/ant-overrides.scss';
 import './scss/index.scss';
+import VerifyEmailPage from './pages/VerifyEmailPage.jsx';
 
 message.config({ maxCount: 1 });
 
@@ -53,6 +54,9 @@ ReactDOM.render(
         </Route>
         <Route exact path="/main">
             <MainPage />
+        </Route>
+        <Route exact path="/verify">
+          <VerifyEmailPage />
         </Route>
       </Switch>
     </Router>

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -3,11 +3,29 @@ import React, { useEffect, useState } from 'react';
 import { Alert } from 'antd';
 import { Link } from 'react-router-dom';
 import { AiOutlineLoading } from 'react-icons/ai';
+import { motion } from 'framer-motion';
 import Card from '../components/Card.jsx';
 import API from '../api/API';
 
+const animationVariants = {
+  hidden: {
+    opacity: 0,
+    transform: 'translateY(50%)',
+  },
+  show: {
+    opacity: 1,
+    transform: 'translateY(0%)',
+  },
+};
+
+const animationOpts = {
+  delay: 0.3,
+  duration: 1.5,
+  ease: [0.16, 1, 0.3, 1],
+};
+
 function VerifyEmailPage() {
-  const [isLoading, setLoading] = useState(false);
+  const [isLoading, setLoading] = useState(true);
   const [hasError, setHasError] = useState(false);
 
   const params = new URLSearchParams(window.location.search);
@@ -33,7 +51,6 @@ function VerifyEmailPage() {
     if (!userId || !verificationCode) {
       return;
     }
-
     verifyEmail();
   }, []);
 
@@ -77,26 +94,34 @@ function VerifyEmailPage() {
   return (
     <div className="verify-email-page">
       <div className="card-container">
-        <Card className="verify-card">
-          <div className="card-title-wrapper">
-            <h2 className="title">Email Verification</h2>
-            {isLoading && (
-              <AiOutlineLoading size={28} className="loading-indicator" />
-            )}
-          </div>
-          {!userId || !verificationCode ? (
-            <Alert
-              type="error"
-              message="Invalid Link"
-              description={`
-                This verification link is invalid. Make sure the
-                URL matches the link from your email.
+        <motion.div
+          initial="hidden"
+          animate="show"
+          transition={animationOpts}
+          variants={animationVariants}
+          className="verify-card-wrapper"
+        >
+          <Card className="verify-card">
+            <div className="card-title-wrapper">
+              <h2 className="title">Email Verification</h2>
+              {isLoading && (
+                <AiOutlineLoading size={28} className="loading-indicator" />
+              )}
+            </div>
+            {!userId || !verificationCode ? (
+              <Alert
+                type="error"
+                message="Invalid Link"
+                description={`
+                  This verification link is invalid. Make sure the
+                  URL matches the link from your email.
               `}
-            />
-          ) : (
-            renderAlert()
-          )}
-        </Card>
+              />
+            ) : (
+              renderAlert()
+            )}
+          </Card>
+        </motion.div>
       </div>
     </div>
   );

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -1,0 +1,99 @@
+import '../scss/verify-email-page.scss';
+import React, { useEffect, useState } from 'react';
+import { Alert } from 'antd';
+import { Link } from 'react-router-dom';
+import { AiOutlineLoading } from 'react-icons/ai';
+import Card from '../components/Card.jsx';
+
+function VerifyEmailPage() {
+  const [isLoading, setLoading] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  const params = new URLSearchParams(window.location.search);
+  const userId = params.get('id');
+  const verificationCode = params.get('code');
+
+  const verifyEmail = () => {
+    // DEBUG: Dummy code to emulate async
+    setLoading(true);
+
+    setTimeout(() => {
+      setLoading(false);
+      setHasError(!!Math.round(Math.random()));
+    }, 3000);
+  };
+
+  useEffect(() => {
+    if (!userId || !verificationCode) {
+      return;
+    }
+
+    verifyEmail();
+  }, []);
+
+  const renderAlert = () => {
+    if (isLoading) {
+      return (
+        <Alert
+          type="info"
+          message="Hold Tight!"
+          description="Just a sec while we verify your email..."
+        />
+      );
+    }
+
+    return hasError ? (
+      <Alert
+        type="error"
+        message="Unexpected Error"
+        description={`
+          An unexpected error occurred. Make sure your email
+          email link is valid and refresh to try again.
+        `}
+      />
+    ) : (
+      <Alert
+        type="success"
+        message="Success!"
+        description={
+          <span>
+            Your email has been verified.{' '}
+            <Link to="/" className="card-link" replace>
+              Click here
+            </Link>{' '}
+            to go back to the login page.
+          </span>
+        }
+      />
+    );
+  };
+
+  return (
+    <div className="verify-email-page">
+      <div className="card-container">
+        <Card className="verify-card">
+          <div className="card-title-wrapper">
+            <h2 className="title">Email Verification</h2>
+            {isLoading && (
+              <AiOutlineLoading size={28} className="loading-indicator" />
+            )}
+          </div>
+          {!userId || !verificationCode ? (
+            <Alert
+              type="error"
+              message="Invalid Link"
+              description={`
+                This verification link is invalid. Make sure the
+                URL matches the link from your email.
+              `}
+            />
+          ) : (
+            renderAlert()
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+export default VerifyEmailPage;

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -47,7 +47,7 @@ function VerifyEmailPage() {
         type="error"
         message="Unexpected Error"
         description={`
-          An unexpected error occurred. Make sure your email
+          An unexpected error occurred. Make sure your
           email link is valid and refresh to try again.
         `}
       />

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -14,7 +14,7 @@ function VerifyEmailPage() {
   const verificationCode = params.get('code');
 
   const verifyEmail = () => {
-    // DEBUG: Dummy code to emulate async
+    // TODO: Make request here, dummy code to emulate async
     setLoading(true);
 
     setTimeout(() => {

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -4,6 +4,7 @@ import { Alert } from 'antd';
 import { Link } from 'react-router-dom';
 import { AiOutlineLoading } from 'react-icons/ai';
 import Card from '../components/Card.jsx';
+import API from '../api/API';
 
 function VerifyEmailPage() {
   const [isLoading, setLoading] = useState(false);
@@ -13,14 +14,19 @@ function VerifyEmailPage() {
   const userId = params.get('id');
   const verificationCode = params.get('code');
 
-  const verifyEmail = () => {
-    // TODO: Make request here, dummy code to emulate async
+  const verifyEmail = async () => {
     setLoading(true);
 
-    setTimeout(() => {
-      setLoading(false);
-      setHasError(!!Math.round(Math.random()));
-    }, 3000);
+    try {
+      await API.verifyEmail(userId, verificationCode);
+    } catch (err) {
+      // TODO: Handle errors here
+    }
+
+    // TODO: Dummy code to test random errors, will be removed
+    setHasError(!!Math.round(Math.random()));
+
+    setLoading(false);
   };
 
   useEffect(() => {

--- a/src/scss/ant-overrides.scss
+++ b/src/scss/ant-overrides.scss
@@ -47,6 +47,10 @@
   font-family: 'DM Sans', Arial, Helvetica, sans-serif;
 }
 
+.ant-alert {
+  border-radius: 6px;
+}
+
 // The title for ant's Alert component
 .ant-alert-message {
   font-weight: 600;

--- a/src/scss/ant-overrides.scss
+++ b/src/scss/ant-overrides.scss
@@ -112,6 +112,10 @@ span.anticon.anticon-delete {
   font-size: 16px !important;
 }
 
+.ant-message-notice {
+  font-size: 16px;
+}
+
 .ant-btn {
   transition: 0.5s;
   border-radius: 5px;

--- a/src/scss/button.scss
+++ b/src/scss/button.scss
@@ -26,6 +26,13 @@
   }
 }
 
+.btn:disabled,
+.btn:disabled:hover {
+  color: hsla(0, 0%, 0%, 0.2);
+  background-color: hsla(0, 0%, 83%, 0.452);
+  cursor: not-allowed;
+}
+
 // Iterate over the color map and construct variants from it's keys and values.
 @each $color, $value in $variant-colors {
   .btn-#{$color} {

--- a/src/scss/invite-area.scss
+++ b/src/scss/invite-area.scss
@@ -38,6 +38,10 @@
     display: flex;
     align-items: center;
     padding: 4px 12px;
+
+    &:hover {
+      background-color: lighten(map-get($variant-colors, 'primary'), 58%);
+    }
   }
 
   .clipboard-icon {

--- a/src/scss/landing.scss
+++ b/src/scss/landing.scss
@@ -128,6 +128,13 @@
   max-height: 550px;
 }
 
+.form-area-success {
+  .resend-text {
+    margin: 16px 0;
+    color: rgba(0, 0, 0, 0.5);
+  }
+}
+
 .landing-card {
   @extend .landing-card;
   padding: 10px;
@@ -140,7 +147,6 @@
 
   .ant-alert {
     align-self: normal;
-    border-radius: 6px;
     text-align: left;
   }
 }

--- a/src/scss/landing.scss
+++ b/src/scss/landing.scss
@@ -156,3 +156,8 @@
   font-weight: 500;
   color: rgba(0,0,0,0.31);
 }
+
+.verify-email-modal .modal-body {
+  margin: 0;
+  color: hsl(0, 0%, 35%);
+}

--- a/src/scss/verify-email-page.scss
+++ b/src/scss/verify-email-page.scss
@@ -16,12 +16,15 @@
     backdrop-filter: blur(4px);
   }
 
+  .verify-card-wrapper {
+    width: 500px;
+    max-width: 500px;
+  }
+
   .verify-card {
     border-radius: 8px;
     margin: 8px;
-    padding: 36px;
-    width: 500px;
-    max-width: 500px;
+    padding: 32px;
     display: flex;
     flex-direction: column;
   }
@@ -54,7 +57,7 @@
     from {
       transform: rotate(0deg);
     }
-  
+
     to {
       transform: rotate(360deg);
     }

--- a/src/scss/verify-email-page.scss
+++ b/src/scss/verify-email-page.scss
@@ -1,0 +1,62 @@
+.verify-email-page {
+  background-image: url('../assets/Splash.png');
+  background-size: cover;
+
+  .card-container {
+    z-index: 9999;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(0, 0, 0, 0.5);
+    backdrop-filter: blur(4px);
+  }
+
+  .verify-card {
+    border-radius: 8px;
+    margin: 8px;
+    padding: 36px;
+    width: 500px;
+    max-width: 500px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .title {
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .ant-alert {
+    margin: 16px 0;
+  }
+
+  .card-link {
+    font-weight: 600;
+    color: #0000cf;
+  }
+
+  .card-title-wrapper {
+    display: flex;
+    align-items: center;
+  }
+
+  .loading-indicator {
+    margin-left: 24px;
+    animation: spin linear infinite 1s;
+  }
+
+  @keyframes spin {
+    from {
+      transform: rotate(0deg);
+    }
+  
+    to {
+      transform: rotate(360deg);
+    }
+  }
+}


### PR DESCRIPTION
This PR also introduces some changes:

* When a new user creates an account, they're no longer automatically redirected to the main page. Instead, they get a message telling them that a verification link has been sent to their email.
* If a user tries to log in but they haven't verified their email, they'll get a message telling them to do so before they're able to log in (you can test this by entering random credentials on the login page, the error is hard coded to always show for now)
* Going to the [`/verify`](http://localhost:3000/verify) route takes you to the verification page but shows an error if the id or verification code is missing from the URL
* Going to something like [`/verify?id=123&code=123`](http://localhost:3000/verify?id=123&code=123) takes you to a page to verify your email (responses are mocked since we're waiting for the API)

Fixes #92