### PR TITLE
Fixes email verification page

### DIFF
--- a/src/api/API.js
+++ b/src/api/API.js
@@ -108,7 +108,7 @@ const API = {
   verifyEmail: async (userId, verificationCode) => fetch(
     relURL(`/users/${userId}/verify`),
     postOptions({ verificationCode }),
-  ),
+  ).then(handleResponse),
 };
 
 export default API;

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -38,13 +38,13 @@ function VerifyEmailPage() {
     setLinkInvalid(false);
 
     try {
-      const res = await API.verifyEmail(userId, verificationCode);
-
-      if (res.status === 404) {
-        setLinkInvalid(true);
-      }
+      await API.verifyEmail(userId, verificationCode);
     } catch (err) {
-      setHasError(true);
+      if (err.status === 404) {
+        setLinkInvalid(true);
+      } else {
+        setHasError(true);
+      }
     }
 
     setLoading(false);

--- a/src/pages/VerifyEmailPage.jsx
+++ b/src/pages/VerifyEmailPage.jsx
@@ -27,6 +27,7 @@ const animationOpts = {
 function VerifyEmailPage() {
   const [isLoading, setLoading] = useState(false);
   const [hasError, setHasError] = useState(false);
+  const [isLinkInvalid, setLinkInvalid] = useState(false);
 
   const params = new URLSearchParams(window.location.search);
   const userId = params.get('id');
@@ -34,9 +35,14 @@ function VerifyEmailPage() {
 
   const verifyEmail = async () => {
     setLoading(true);
+    setLinkInvalid(false);
 
     try {
-      await API.verifyEmail(userId, verificationCode);
+      const res = await API.verifyEmail(userId, verificationCode);
+
+      if (res.status === 404) {
+        setLinkInvalid(true);
+      }
     } catch (err) {
       setHasError(true);
     }
@@ -51,6 +57,17 @@ function VerifyEmailPage() {
     verifyEmail();
   }, []);
 
+  const invalidLinkAlert = (
+    <Alert
+      type="error"
+      message="Invalid Link"
+      description={`
+        This verification link is invalid. Make sure the
+        URL matches the link from your email.
+    `}
+    />
+  );
+
   const renderAlert = () => {
     if (isLoading) {
       return (
@@ -60,6 +77,10 @@ function VerifyEmailPage() {
           description="Just a sec while we verify your email..."
         />
       );
+    }
+
+    if (isLinkInvalid) {
+      return invalidLinkAlert;
     }
 
     return hasError ? (
@@ -105,18 +126,7 @@ function VerifyEmailPage() {
                 <AiOutlineLoading size={28} className="loading-indicator" />
               )}
             </div>
-            {!userId || !verificationCode ? (
-              <Alert
-                type="error"
-                message="Invalid Link"
-                description={`
-                  This verification link is invalid. Make sure the
-                  URL matches the link from your email.
-              `}
-              />
-            ) : (
-              renderAlert()
-            )}
+            {!userId || !verificationCode ? invalidLinkAlert : renderAlert()}
           </Card>
         </motion.div>
       </div>


### PR DESCRIPTION
Turns out there was a missing `.then` after the request. That caused errors not to bubble up and showed the success message when it should've showed an error message