### PR TITLE
Adds ability to upload images to groups

### DIFF
--- a/src/api/API.js
+++ b/src/api/API.js
@@ -47,6 +47,17 @@ const postOptions = body => ({
  * @property {String} URL
  */
 
+/**
+ * @typedef ImageUploadResponse
+ * @property {String} caption
+ * @property {String} fileName
+ * @property {String} creator
+ * @property {String} groupId
+ * @property {String} dateUploaded
+ * @property {String} URL
+ * @property {String} id
+ */
+
 const API = {
   /**
    * Logs user into account.
@@ -161,6 +172,44 @@ const API = {
    */
   getGroupImages: async groupId => fetch(relURL(`/groups/${groupId}/images`))
     .then(handleResponse),
+
+  /**
+   * Uploads an image or GIF to the specified group.
+   *
+   * @typedef {Object} ImageUploadOptions
+   * @property {File} image
+   * @property {string} userId
+   * @property {string} groupId
+   * @property {string?} caption
+   *
+   * @param {ImageUploadOptions} payload
+   * @throws {APIError} On server error.
+   * @returns {Promise<ImageUploadResponse>}
+   */
+  uploadGroupImage: async ({
+    image,
+    userId,
+    groupId,
+    caption,
+  }) => {
+    const formDate = new FormData();
+
+    formDate.append('groupPicture', image);
+    formDate.append('userId', userId);
+
+    if (caption) {
+      formDate.append('caption', caption);
+    }
+
+    const options = {
+      method: 'PUT',
+      body: formDate,
+    };
+
+    return fetch(relURL(`/groups/${groupId}/uploadImage`), options).then(
+      handleResponse,
+    );
+  },
 };
 
 export default API;

--- a/src/components/CreateGroupModal.jsx
+++ b/src/components/CreateGroupModal.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import '../scss/create-group-modal.scss';
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
@@ -15,7 +14,7 @@ import { AiOutlinePlus, AiOutlineUser, AiOutlineDelete } from 'react-icons/ai';
 import UserContext from '../contexts/UserContext.jsx';
 import GroupsContextDispatch from '../contexts/GroupsContextDispatch.jsx';
 import API from '../api/API';
-import GroupsStateContext from '../contexts/GroupStateContext';
+import GroupsStateContext from '../contexts/GroupStateContext.jsx';
 
 function CreateGroupModal({ visible, onClose }) {
   const [groupName, setGroupName] = useState('');
@@ -59,7 +58,7 @@ function CreateGroupModal({ visible, onClose }) {
   const createGroup = async event => {
     event.preventDefault();
 
-    if (isLoading) {
+    if (isLoading || !groupName.trim()) {
       return;
     }
 
@@ -80,10 +79,9 @@ function CreateGroupModal({ visible, onClose }) {
         type: 'addGroup',
         payload: {
           group,
-          index: groups.length
+          index: groups.length,
         },
       });
-  
     } catch (err) {
       notification.error({
         message: 'Error creating group',

--- a/src/components/CreateGroupModal.jsx
+++ b/src/components/CreateGroupModal.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import '../scss/create-group-modal.scss';
 import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
@@ -14,6 +15,7 @@ import { AiOutlinePlus, AiOutlineUser, AiOutlineDelete } from 'react-icons/ai';
 import UserContext from '../contexts/UserContext.jsx';
 import GroupsContextDispatch from '../contexts/GroupsContextDispatch.jsx';
 import API from '../api/API';
+import GroupsStateContext from '../contexts/GroupStateContext';
 
 function CreateGroupModal({ visible, onClose }) {
   const [groupName, setGroupName] = useState('');
@@ -21,6 +23,7 @@ function CreateGroupModal({ visible, onClose }) {
   const [memberEmail, setMemberEmail] = useState('');
   const [members, setMembers] = useState(new Set());
   const [isLoading, setLoading] = useState(false);
+  const { groups } = useContext(GroupsStateContext);
   const dispatch = useContext(GroupsContextDispatch);
   const user = useContext(UserContext);
 
@@ -70,10 +73,17 @@ function CreateGroupModal({ visible, onClose }) {
         emails: [...members],
       });
 
+      // Passing the length of the user's groups here so that the
+      // currently selected group index  will always be the
+      // newly created group index (essentially groups[groups.length - 1])
       dispatch({
         type: 'addGroup',
-        payload: group,
+        payload: {
+          group,
+          index: groups.length
+        },
       });
+  
     } catch (err) {
       notification.error({
         message: 'Error creating group',

--- a/src/components/ImageUploadModal.jsx
+++ b/src/components/ImageUploadModal.jsx
@@ -82,9 +82,7 @@ function ImageUploadModal({ visible, onClose }) {
         image: file,
         caption: imageCaption,
         userId: user.id,
-        // TODO: Remove the _id check
-        // eslint-disable-next-line no-underscore-dangle
-        groupId: groups[index]._id || groups[index].id,
+        groupId: groups[index].id,
       });
 
       onRequestClose();

--- a/src/components/ImageUploadModal.jsx
+++ b/src/components/ImageUploadModal.jsx
@@ -27,7 +27,11 @@ function ImageUploadModal({ visible, onClose }) {
   // Adds a custom input below ant's list item component
   const renderListItem = originNode => (
     <>
-      <Tooltip title="Click to preview" mouseEnterDelay={0.7}>
+      <Tooltip
+        title="Click to preview"
+        mouseEnterDelay={0.5}
+        mouseLeaveDelay={0}
+      >
         {originNode}
       </Tooltip>
       <div className="input-wrapper">
@@ -78,7 +82,7 @@ function ImageUploadModal({ visible, onClose }) {
       // Opening a new window that's on a different domain prevents
       // us from modifying that tab's title and styling so we need
       // to do that manually using document.write
-      newWindow.document.write(/* html */`
+      newWindow.document.write(/* html */ `
         <title>Preview</title>
         <style>
           body {

--- a/src/components/ImageUploadModal.jsx
+++ b/src/components/ImageUploadModal.jsx
@@ -7,6 +7,7 @@ import {
   Alert,
   Input,
   Tooltip,
+  notification,
 } from 'antd';
 import PropTypes from 'prop-types';
 import { AiOutlineCloudUpload } from 'react-icons/ai';
@@ -14,6 +15,9 @@ import GroupStateContext from '../contexts/GroupStateContext.jsx';
 import UserContext from '../contexts/UserContext.jsx';
 import GroupContextDispatch from '../contexts/GroupsContextDispatch.jsx';
 import API from '../api/API';
+
+// 2 megabytes
+const MAX_FILE_SIZE = 2e+6;
 
 function ImageUploadModal({ visible, onClose }) {
   const [imageCaption, setImageCaption] = useState('');
@@ -111,6 +115,18 @@ function ImageUploadModal({ visible, onClose }) {
     event.preventDefault();
 
     if (isUploading || !file) {
+      return;
+    }
+
+    if (file.size >= MAX_FILE_SIZE) {
+      notification.error({
+        key: 'file-too-large-error',
+        message: 'File Too Large',
+        description: `
+          This file is too large to upload.
+          The max file size is ${MAX_FILE_SIZE / 1e6} MB.
+        `,
+      });
       return;
     }
 

--- a/src/components/ImageUploadModal.jsx
+++ b/src/components/ImageUploadModal.jsx
@@ -74,6 +74,10 @@ function ImageUploadModal({ visible, onClose }) {
       previewImage.onload = () => URL.revokeObjectURL(previewImage.src);
 
       const newWindow = window.open(thumbUrl, '_blank');
+
+      // Opening a new window that's on a different domain prevents
+      // us from modifying that tab's title and styling so we need
+      // to do that manually using document.write
       newWindow.document.write(/* html */`
         <title>Preview</title>
         <style>

--- a/src/components/dashboard/FloatingButton.jsx
+++ b/src/components/dashboard/FloatingButton.jsx
@@ -5,9 +5,9 @@ import '../../scss/floating-button.scss';
 
 function FloatingButton({ onClick, children }) {
   return (
-        <button onClick={onClick} className="floating-button">
-            {children}
-        </button>
+    <button onClick={onClick} className="floating-button">
+      {children}
+    </button>
   );
 }
 

--- a/src/components/dashboard/GroupList.jsx
+++ b/src/components/dashboard/GroupList.jsx
@@ -18,14 +18,13 @@ function GroupList({ groups, activeIndex, onGroupClick }) {
     </Avatar>
   );
 
-  const renderListItem = ({ name, thumbnail }, index) => (
+  const renderListItem = ({ name, thumbnail, memberCount }, index) => (
     <List.Item onClick={() => onGroupClick(index)} title={name}>
       <List.Item.Meta
         className={index === activeIndex ? 'selected' : ''}
         avatar={renderGroupImage(thumbnail, name)}
         title={name}
-        // TODO: Replace with actual group member count
-        description={getMemberText(100)}
+        description={getMemberText(memberCount)}
       />
     </List.Item>
   );
@@ -53,7 +52,7 @@ GroupList.propTypes = {
     PropTypes.shape({
       title: PropTypes.string,
       imageURL: PropTypes.string,
-      members: PropTypes.number,
+      memberCount: PropTypes.number,
     }),
   ),
   activeIndex: PropTypes.number,

--- a/src/components/dashboard/GroupList.jsx
+++ b/src/components/dashboard/GroupList.jsx
@@ -24,7 +24,7 @@ function GroupList({ groups, activeIndex, onGroupClick }) {
         className={index === activeIndex ? 'selected' : ''}
         avatar={renderGroupImage(thumbnail, name)}
         title={name}
-        description={getMemberText(memberCount)}
+        description={getMemberText(memberCount || 1)}
       />
     </List.Item>
   );

--- a/src/components/dashboard/GroupList.jsx
+++ b/src/components/dashboard/GroupList.jsx
@@ -53,6 +53,9 @@ GroupList.propTypes = {
       title: PropTypes.string,
       imageURL: PropTypes.string,
       memberCount: PropTypes.number,
+      thumbnail: PropTypes.shape({
+        URL: PropTypes.string,
+      }),
     }),
   ),
   activeIndex: PropTypes.number,

--- a/src/components/dashboard/GroupList.jsx
+++ b/src/components/dashboard/GroupList.jsx
@@ -13,7 +13,7 @@ function GroupList({ groups, activeIndex, onGroupClick }) {
   };
 
   const renderGroupImage = (thumbnail, title) => (
-    <Avatar src={thumbnail} size={54} alt={title}>
+    <Avatar src={thumbnail && thumbnail.URL} size={54} alt={title}>
       {title[0]}
     </Avatar>
   );

--- a/src/components/dashboard/InviteArea.jsx
+++ b/src/components/dashboard/InviteArea.jsx
@@ -39,7 +39,7 @@ function InviteArea({ inviteCode, groupId }) {
       return;
     }
 
-    copyToClipboard(`https://${inviteLink}`)
+    copyToClipboard(`https://www.${inviteLink}`)
       .then(() => message.success('Link copied to clipboard.'))
       .catch(() => message.error('Error copying code.'));
   };

--- a/src/components/dashboard/Navbar.jsx
+++ b/src/components/dashboard/Navbar.jsx
@@ -1,12 +1,7 @@
 import '../../scss/navbar.scss';
 import React, { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Avatar,
-  Layout,
-  Dropdown,
-
-} from 'antd';
+import { Avatar, Layout, Dropdown } from 'antd';
 import UserMenu from './UserMenu.jsx';
 import UserContext from '../../contexts/UserContext.jsx';
 
@@ -39,16 +34,19 @@ function Navbar({ onLogout }) {
       <div className="invisible-backing" />
       <Header className="navbar">
         <h1 className="title">ImageUs</h1>
-        <Dropdown overlay={<UserMenu onLogout={onLogout}/>} trigger={['click']}>
-        <Avatar
-          size={40}
-          src={imgURL}
-          alt={initials}
-          className="avatar-button"
+        <Dropdown
+          overlay={<UserMenu onLogout={onLogout} />}
+          trigger={['click']}
         >
-          {initials}
-        </Avatar>
-    </Dropdown>
+          <Avatar
+            size={40}
+            src={imgURL}
+            alt={initials}
+            className="avatar-button"
+          >
+            {initials}
+          </Avatar>
+        </Dropdown>
       </Header>
     </div>
   );

--- a/src/components/dashboard/PhotoGrid.jsx
+++ b/src/components/dashboard/PhotoGrid.jsx
@@ -27,7 +27,7 @@ function PhotoGrid({ photos }) {
         <AnimatePresence exitBeforeEnter>
           <motion.div
             initial={{ opacity: 0, y: '25%' }}
-            key="photo-container"
+            key={photos.length > 0 ? photos[0].URL : ''}
             animate={{ opacity: 1, y: 0 }}
             exit={{
               opacity: 0,

--- a/src/components/dashboard/PhotoGrid.jsx
+++ b/src/components/dashboard/PhotoGrid.jsx
@@ -25,7 +25,7 @@ function PhotoGrid({ photos }) {
         <AnimatePresence exitBeforeEnter>
           <motion.div
             initial={{ opacity: 0, y: '25%' }}
-            key={photos[0]} // Todo Change me later
+            key={photos[0]}
             animate={{ opacity: 1, y: 0 }}
             exit={{
               opacity: 0,

--- a/src/components/dashboard/PhotoGrid.jsx
+++ b/src/components/dashboard/PhotoGrid.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import PropTypes from 'prop-types';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Image } from 'antd';
@@ -6,6 +6,7 @@ import { AiOutlineCloudUpload } from 'react-icons/ai';
 import PhotoThumbnail from './PhotoThumbnail.jsx';
 import FloatingButton from './FloatingButton.jsx';
 import ImageUploadModal from '../ImageUploadModal.jsx';
+import GroupStateContext from '../../contexts/GroupStateContext.jsx';
 
 import '../../scss/photo-grid.scss';
 
@@ -18,6 +19,7 @@ function PhotoGrid({ photos }) {
   const [isUploadModalVisible, setUploadModalVisible] = useState(false);
   const openUploadModal = () => setUploadModalVisible(true);
   const closeUploadModal = () => setUploadModalVisible(false);
+  const { groups } = useContext(GroupStateContext);
 
   return (
     <div className="photo-grid-container">
@@ -47,9 +49,11 @@ function PhotoGrid({ photos }) {
             </div>
           </motion.div>
         </AnimatePresence>
-        <FloatingButton onClick={openUploadModal}>
-          <AiOutlineCloudUpload size={32} color="#525252" />
-        </FloatingButton>
+        {groups.length > 0 && (
+          <FloatingButton onClick={openUploadModal}>
+            <AiOutlineCloudUpload size={32} color="#525252" />
+          </FloatingButton>
+        )}
       </Image.PreviewGroup>
       <ImageUploadModal
         visible={isUploadModalVisible}

--- a/src/components/dashboard/PhotoGrid.jsx
+++ b/src/components/dashboard/PhotoGrid.jsx
@@ -43,7 +43,11 @@ function PhotoGrid({ photos }) {
             <div className="photo-grid">
               {photos.map(photo => (
                 <motion.div key={photo.URL} variants={item}>
-                  <PhotoThumbnail key={photo.URL} src={photo.URL} />
+                  <PhotoThumbnail
+                    key={photo.URL}
+                    src={photo.URL}
+                    caption={photo.caption}
+                  />
                 </motion.div>
               ))}
             </div>

--- a/src/components/dashboard/PhotoGrid.jsx
+++ b/src/components/dashboard/PhotoGrid.jsx
@@ -27,7 +27,7 @@ function PhotoGrid({ photos }) {
         <AnimatePresence exitBeforeEnter>
           <motion.div
             initial={{ opacity: 0, y: '25%' }}
-            key={photos[0]}
+            key="photo-container"
             animate={{ opacity: 1, y: 0 }}
             exit={{
               opacity: 0,
@@ -42,8 +42,8 @@ function PhotoGrid({ photos }) {
           >
             <div className="photo-grid">
               {photos.map(photo => (
-                <motion.div key={photo} variants={item}>
-                  <PhotoThumbnail key={photo} src={photo} />
+                <motion.div key={photo.URL} variants={item}>
+                  <PhotoThumbnail key={photo.URL} src={photo.URL} />
                 </motion.div>
               ))}
             </div>
@@ -64,7 +64,12 @@ function PhotoGrid({ photos }) {
 }
 
 PhotoGrid.propTypes = {
-  photos: PropTypes.arrayOf(String).isRequired,
+  photos: PropTypes.arrayOf(
+    PropTypes.shape({
+      URL: PropTypes.string.isRequired,
+      caption: PropTypes.string,
+    }),
+  ).isRequired,
 };
 
 export default PhotoGrid;

--- a/src/components/dashboard/PhotoThumbnail.jsx
+++ b/src/components/dashboard/PhotoThumbnail.jsx
@@ -7,6 +7,7 @@ import fallback from '../../assets/errorimage.png';
 function PhotoThumbnail({ src, caption }) {
   return (
     <motion.div
+      className="thumbnail-wrapper"
       transition={{
         duration: 1,
         type: 'spring',
@@ -29,14 +30,12 @@ function PhotoThumbnail({ src, caption }) {
         },
       }}
     >
-      <div className="thumbnail-container">
-        <Image className="photo-thumbnail" src={src} fallback={fallback} />
-        {caption && (
-          <div className="thumbnail-caption">
-            <p className="caption">{caption}</p>
-          </div>
-        )}
-      </div>
+      <Image className="photo-thumbnail" src={src} fallback={fallback} />
+      {caption && (
+        <div className="thumbnail-caption">
+          <p className="caption">{caption}</p>
+        </div>
+      )}
     </motion.div>
   );
 }

--- a/src/components/dashboard/PhotoThumbnail.jsx
+++ b/src/components/dashboard/PhotoThumbnail.jsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion';
 import { Image } from 'antd';
 import fallback from '../../assets/errorimage.png';
 
-function PhotoThumbnail({ src }) {
+function PhotoThumbnail({ src, caption }) {
   return (
     <motion.div
       transition={{
@@ -29,17 +29,25 @@ function PhotoThumbnail({ src }) {
         },
       }}
     >
-      <Image
-        className="photo-thumbnail"
-        src={src}
-        fallback={fallback}
-      />
+      <div className="thumbnail-container">
+        <Image className="photo-thumbnail" src={src} fallback={fallback} />
+        {caption && (
+          <div className="thumbnail-caption">
+            <p className="caption">{caption}</p>
+          </div>
+        )}
+      </div>
     </motion.div>
   );
 }
 
 PhotoThumbnail.propTypes = {
   src: PropTypes.string.isRequired,
+  caption: PropTypes.string,
+};
+
+PhotoThumbnail.defaultProps = {
+  caption: '',
 };
 
 export default PhotoThumbnail;

--- a/src/components/dashboard/PhotoThumbnail.jsx
+++ b/src/components/dashboard/PhotoThumbnail.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { motion } from 'framer-motion';

--- a/src/components/dashboard/Sidebar.jsx
+++ b/src/components/dashboard/Sidebar.jsx
@@ -24,7 +24,9 @@ function Sidebar() {
   useEffect(() => {
     if (groups.length > 0) {
       setInviteCode(groups[index].inviteCode);
-      setGroupId(groups[index].id);
+      // TODO: Remove the _id check
+      // eslint-disable-next-line no-underscore-dangle
+      setGroupId(groups[index]._id || groups[index].id);
     } else {
       setInviteCode('');
       setGroupId('');

--- a/src/contexts/GroupsContextDispatch.jsx
+++ b/src/contexts/GroupsContextDispatch.jsx
@@ -3,21 +3,38 @@ import { createContext } from 'react';
 const GroupsDispatchContext = createContext(null);
 
 function groupReducer(state, action) {
+  const { index } = action.payload;
+
   switch (action.type) {
     case 'setIndex':
       return {
         ...state,
         index: action.payload,
       };
+    case 'setImages':
+      return {
+        ...state,
+        images: action.payload,
+      };
     case 'addGroup':
+      // Side note: index is here is optional. If passed, this will cause the
+      // state to update the index which will in turn set the selected group
+      // to the value of index. If index isn't passed, the selected group
+      // will remain unchanged.
       return {
         ...state,
         groups: [...state.groups, action.payload.group],
-        index: action.payload.index,
+        index: index === null || index === undefined ? state.index : index,
+      };
+    case 'addImage':
+      return {
+        ...state,
+        images: [...state.images, action.payload],
       };
     case 'init':
       return {
         groups: action.payload.groups,
+        images: action.payload.images,
         index: action.payload.index,
       };
     default:

--- a/src/contexts/GroupsContextDispatch.jsx
+++ b/src/contexts/GroupsContextDispatch.jsx
@@ -12,10 +12,14 @@ function groupReducer(state, action) {
     case 'addGroup':
       return {
         ...state,
-        groups: [...state.groups, action.payload],
+        groups: [...state.groups, action.payload.group],
+        index: action.payload.index,
       };
     case 'init':
-      return { groups: action.payload, index: 0 };
+      return {
+        groups: action.payload.groups,
+        index: action.payload.index,
+      };
     default:
       throw new Error('Invalid Group reducer action.');
   }

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -35,7 +35,7 @@ function MainPage() {
   const [user, setUser] = useState({});
   // Using an initial value of -1 here so that groupData can
   // trigger updates when it's value is set to 0 on mount.
-  // (It'll be set to 0 even if there are no groups)
+  // It'll be set to 0 even if there is at least ont group to load
   const [groupData, dispatch] = useReducer(groupReducer, {
     groups: [],
     index: -1,
@@ -139,7 +139,15 @@ function MainPage() {
       return;
     }
 
-    dispatch({ type: 'init', payload: groups });
+    // Set the index to -1 if there are no groups to load so
+    // that it can be updated once a new group is added
+    dispatch({
+      type: 'init',
+      payload: {
+        groups,
+        index: groups.length === 0 ? -1 : 0,
+      },
+    });
   }, []);
 
   // Triggers when group changes
@@ -153,7 +161,7 @@ function MainPage() {
       <GroupDispatchContext.Provider value={dispatch}>
         <GroupsStateContext.Provider value={groupData}>
           <div className="main-page-body">
-            <Navbar onLogout={logout}/>
+            <Navbar onLogout={logout} />
             <div className="body-content">
               <Sidebar />
               <div className="main-content">
@@ -161,18 +169,20 @@ function MainPage() {
                   style={{ display: 'flex', justifyContent: 'space-between' }}
                 >
                   <h1>{groupTitle}</h1>
-                  <Button
-                    type="primary"
-                    size="large"
-                    shape="circle"
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'center',
-                      alignItems: 'center',
-                    }}
-                  >
-                    <BsThreeDots />
-                  </Button>
+                  {groupData.groups.length > 0 && (
+                    <Button
+                      type="primary"
+                      size="large"
+                      shape="circle"
+                      style={{
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <BsThreeDots />
+                    </Button>
+                  )}
                 </div>
                 <PhotoGrid photos={photos} />
               </div>

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -70,11 +70,7 @@ function MainPage() {
     setGroupTitle(groups[index].name);
 
     try {
-      // TODO: Remove the _id check
-      const res = await API.getGroupImages(
-        // eslint-disable-next-line no-underscore-dangle
-        groups[index]._id || groups[index].id,
-      );
+      const res = await API.getGroupImages(groups[index].id);
 
       setPhotos(res.images.map(img => img.URL));
     } catch (err) {

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -74,6 +74,7 @@ function MainPage() {
       setPhotos(res.images.map(img => img.URL));
     } catch (err) {
       notification.error({
+        key: 'error-build-photo',
         message: 'Unexpected Error',
         description: `
           An error occurred while this group's images.
@@ -93,6 +94,7 @@ function MainPage() {
         history.replace('/');
       } else {
         notification.error({
+          key: 'error-get-user',
           message: 'Unexpected Error',
           description: `
           An unexpected error occurred while loading
@@ -130,6 +132,7 @@ function MainPage() {
 
     if (!groups) {
       notification.error({
+        key: 'error-init',
         message: 'Unexpected Error',
         description: `
           An error occurred while loading
@@ -165,21 +168,10 @@ function MainPage() {
             <div className="body-content">
               <Sidebar />
               <div className="main-content">
-                <div
-                  style={{ display: 'flex', justifyContent: 'space-between' }}
-                >
-                  <h1>{groupTitle}</h1>
+                <div className="group-title-row">
+                  <h1 className="group-title" title={groupTitle}>{groupTitle}</h1>
                   {groupData.groups.length > 0 && (
-                    <Button
-                      type="primary"
-                      size="large"
-                      shape="circle"
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                      }}
-                    >
+                    <Button className="group-action-btn" type="primary">
                       <BsThreeDots />
                     </Button>
                   )}

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -70,7 +70,12 @@ function MainPage() {
     setGroupTitle(groups[index].name);
 
     try {
-      const res = await API.getGroupImages(groups[index].id);
+      // TODO: Remove the _id check
+      const res = await API.getGroupImages(
+        // eslint-disable-next-line no-underscore-dangle
+        groups[index]._id || groups[index].id,
+      );
+
       setPhotos(res.images.map(img => img.URL));
     } catch (err) {
       notification.error({
@@ -87,8 +92,8 @@ function MainPage() {
   async function getUser(token, userId) {
     try {
       return await API.getInfo(token, userId);
-    } catch (e) {
-      if (e.status === 403) {
+    } catch (err) {
+      if (err.status === 403) {
         // The user isn't authenticated, take them back
         // to the login page
         history.replace('/');
@@ -169,7 +174,9 @@ function MainPage() {
               <Sidebar />
               <div className="main-content">
                 <div className="group-title-row">
-                  <h1 className="group-title" title={groupTitle}>{groupTitle}</h1>
+                  <h1 className="group-title" title={groupTitle}>
+                    {groupTitle}
+                  </h1>
                   {groupData.groups.length > 0 && (
                     <Button className="group-action-btn" type="primary">
                       <BsThreeDots />

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -18,8 +18,8 @@ import GroupsStateContext from '../contexts/GroupStateContext.jsx';
 function MainPage() {
   const [user, setUser] = useState({});
   // Using an initial value of -1 here so that groupData can
-  // trigger updates when it's value is set to 0 on mount.
-  // It'll be set to 0 even if there is at least ont group to load
+  // trigger updates when its value is set to 0 on mount.
+  // It'll be set to 0 if there is at least one group to load.
   const [groupData, dispatch] = useReducer(groupReducer, {
     groups: [],
     images: [],

--- a/src/scss/ant-overrides.scss
+++ b/src/scss/ant-overrides.scss
@@ -25,7 +25,6 @@
   padding-bottom: 24px;
 }
 
-
 .ant-modal-footer {
   border-top: none;
   padding-top: 0;
@@ -116,6 +115,10 @@ span.anticon.anticon-delete {
   font-size: 16px;
 }
 
+.ant-dropdown {
+  box-shadow: rgb(0, 0, 0, 20%) 0px 5px 15px;
+}
+
 .ant-btn {
   transition: 0.5s;
   border-radius: 5px;
@@ -142,12 +145,21 @@ span.anticon.anticon-delete {
   .ant-btn.ant-btn-#{$color} {
     color: $value;
     background-color: lighten(rgba($value, 0.2), 35%);
-    
 
     &:hover {
       background-color: $value;
       color: white;
       transition: 0.5s;
     }
+  }
+}
+
+.ant-btn-dangerous {
+  $danger-color: map-get($variant-colors, 'danger');
+  color: $danger-color;
+
+  &:hover {
+    background-color: lighten(rgba($danger-color, 0.2), 35%);
+    color: $danger-color;
   }
 }

--- a/src/scss/floating-button.scss
+++ b/src/scss/floating-button.scss
@@ -23,4 +23,8 @@
         transition: 400ms;
         box-shadow: rgba(0, 0, 0, 0.3) 0px 19px 38px, rgba(0, 0, 0, 0.22) 0px 15px 12px;
     }
+
+    &:focus {
+        outline: none;
+    }
 }

--- a/src/scss/image-upload-modal.scss
+++ b/src/scss/image-upload-modal.scss
@@ -28,4 +28,11 @@
     margin-bottom: 8px;
     font-family: 'Poppins', Arial, Helvetica, sans-serif;
   }
+
+  .group-hint {
+    font-size: 15px;
+    margin-top: 8px;
+    margin-bottom: 0;
+    color: hsl(0, 0%, 35%);
+  }
 }

--- a/src/scss/image-upload-modal.scss
+++ b/src/scss/image-upload-modal.scss
@@ -3,6 +3,10 @@
     margin-top: 24px;
   }
 
+  .ant-upload-span {
+    cursor: pointer;
+  }
+
   .ant-alert {
     margin-bottom: 16px;
   }

--- a/src/scss/main-page.scss
+++ b/src/scss/main-page.scss
@@ -22,4 +22,30 @@
     overflow: auto;
     margin: 0;
   }
+  .group-title-row {
+    display: flex;
+    align-items: center;
+  }
+
+  .group-title {
+    margin-bottom: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .group-action-btn {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    font-size: 32px;
+    margin-left: 24px;
+
+    svg {
+      transform: scale(1.5);
+    }
+  }
 }

--- a/src/scss/main-page.scss
+++ b/src/scss/main-page.scss
@@ -25,6 +25,7 @@
   .group-title-row {
     display: flex;
     align-items: center;
+    margin-bottom: 8px;
   }
 
   .group-title {

--- a/src/scss/navbar.scss
+++ b/src/scss/navbar.scss
@@ -25,12 +25,17 @@
     height: $navbar-height;
     width: 100%;
   }
+
+  .avatar-button {
+    cursor: pointer;
+  }
+
+  .ant-avatar-string {
+    font-weight: 700;
+    text-transform: uppercase;
+  }
 }
 
 .invisible-backing {
   height: $navbar-height;
-}
-
-.avatar-button {
-  cursor: pointer;
 }

--- a/src/scss/photo-grid.scss
+++ b/src/scss/photo-grid.scss
@@ -5,24 +5,12 @@
   flex-wrap: wrap;
 }
 
-.photo-thumbnail {
-  width: 250px;
-  height: 200px;
-  overflow: hidden;
-  margin: 10px;
-  object-fit: cover;
+.thumbnail-wrapper {
   border-radius: 20px;
-  transition: 400ms;
-  overflow: hidden;
-}
-
-.thumbnail-container {
+  margin: 10px;
   position: relative;
-  overflow: hidden;
-
-  &:hover .thumbnail-caption {
-    opacity: 1;
-  }
+  transition: box-shadow 400ms ease-in-out;
+  cursor: pointer;
 
   .thumbnail-caption {
     border-bottom-left-radius: 20px;
@@ -34,10 +22,9 @@
     font-family: 'DM Sans', Arial, Helvetica, sans-serif;
     text-align: center;
     position: absolute;
-    bottom: 7px;
+    bottom: 0px;
     left: 0;
     right: 0;
-    margin: 10px;
     opacity: 0;
     transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
 
@@ -48,20 +35,37 @@
       white-space: nowrap;
     }
   }
+
+  &:hover {
+    box-shadow: map-get($box-shadows, 'md');
+    .thumbnail-caption {
+      opacity: 1;
+    }
+  }
+}
+
+.photo-thumbnail {
+  width: 250px;
+  height: 200px;
+  overflow: hidden;
+  object-fit: cover;
+  transition: 400ms;
+  overflow: hidden;
 }
 
 .ant-image {
   background-color: transparent !important;
   transition: 400ms;
+  display: inline;
+
+  img {
+    border-radius: 20px;
+  }
 }
 
 .ant-image:hover {
   transition: 400ms;
   background-color: transparent !important;
-
-  img {
-    box-shadow: map-get($map: $box-shadows, $key: 'md');
-  }
 }
 
 .ant-image-mask {

--- a/src/scss/photo-grid.scss
+++ b/src/scss/photo-grid.scss
@@ -1,39 +1,74 @@
 @import 'variables';
 
 .photo-grid {
-    display: flex;
-    flex-wrap: wrap;
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .photo-thumbnail {
-    width: 250px;
-    height: 200px;
-    overflow: hidden;
+  width: 250px;
+  height: 200px;
+  overflow: hidden;
+  margin: 10px;
+  object-fit: cover;
+  border-radius: 20px;
+  transition: 400ms;
+  overflow: hidden;
+}
+
+.thumbnail-container {
+  position: relative;
+  overflow: hidden;
+
+  &:hover .thumbnail-caption {
+    opacity: 1;
+  }
+
+  .thumbnail-caption {
+    border-bottom-left-radius: 20px;
+    border-bottom-right-radius: 20px;
+    background-color: hsl(0, 0%, 10%);
+    color: white;
+    padding: 4px;
+    font-size: 14px;
+    font-family: 'DM Sans', Arial, Helvetica, sans-serif;
+    text-align: center;
+    position: absolute;
+    bottom: 5px;
+    left: 0;
+    right: 0;
     margin: 10px;
-    object-fit: cover;
-    border-radius: 20px;
-    transition: 400ms;
+    opacity: 0;
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+
+    .caption {
+      margin: 0 12px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
 }
 
 .ant-image {
-    background-color: transparent !important;
-    transition: 400ms;
+  background-color: transparent !important;
+  transition: 400ms;
 }
 
 .ant-image:hover {
-    transition: 400ms;
-    background-color: transparent !important;
-    
-    img {
-        box-shadow: map-get($map: $box-shadows, $key: 'md');
-    }
+  transition: 400ms;
+  background-color: transparent !important;
+
+  img {
+    box-shadow: map-get($map: $box-shadows, $key: 'md');
+  }
 }
 
 .ant-image-mask {
-    background-color: transparent !important;
+  background-color: transparent !important;
 }
 
 .ant-image-mask-info {
-    background-color: transparent !important;
-    display: none;
+  background-color: transparent !important;
+  display: none;
 }

--- a/src/scss/photo-grid.scss
+++ b/src/scss/photo-grid.scss
@@ -27,14 +27,14 @@
   .thumbnail-caption {
     border-bottom-left-radius: 20px;
     border-bottom-right-radius: 20px;
-    background-color: hsl(0, 0%, 10%);
+    background-color: hsla(0, 0%, 10%, 70%);
     color: white;
-    padding: 4px;
+    padding: 6px;
     font-size: 14px;
     font-family: 'DM Sans', Arial, Helvetica, sans-serif;
     text-align: center;
     position: absolute;
-    bottom: 5px;
+    bottom: 7px;
     left: 0;
     right: 0;
     margin: 10px;


### PR DESCRIPTION
This PR also improves the quality of the image preview once opened in a new tab. Only JPG, JPEG, PNG, and GIF files are currently allowed.

Quick side note: This PR also fixes a bug that occurred when creating a new group in an empty user. Creating a new group when there are none should now properly display that newly created group. Creating other new groups will focus that group in the sidebar.

Quick side note (pt. 2): This PR slightly changes the way we handled state management for groups. We now have a separate array for groups and photos. This allows you to react to updates on group creation, group switching, and image loading.

Fixes #93 