### PR TITLE
Hotfix for empty creator list and leaving single group in list.

### DIFF
--- a/src/api/API.js
+++ b/src/api/API.js
@@ -274,9 +274,9 @@ const API = {
    * @returns {Promise}
    * @throws {APIError} On server error.
    */
-  async removeUsers(groupId, userIds) {
+  async removeUser(groupId, userId) {
     return axios
-      .delete(`/groups/${groupId}/removeUsers`, { data: { users: userIds } })
+      .delete(`/groups/${groupId}/removeUser`, { data: { user: userId } })
       .then(response => response.data);
   },
 

--- a/src/api/API.js
+++ b/src/api/API.js
@@ -269,7 +269,7 @@ const API = {
    * Removes a user from a group for each given user ID.
    *
    * @param {string} groupId
-   * @param {string[]} userIds
+   * @param {string} userId
    *
    * @returns {Promise}
    * @throws {APIError} On server error.

--- a/src/components/dashboard/GroupMenuButton.jsx
+++ b/src/components/dashboard/GroupMenuButton.jsx
@@ -55,7 +55,7 @@ function GroupMenu({ className, isOwner }) {
 
   async function leaveGroup() {
     try {
-      await API.removeUsers(groups[index].id, [loggedInUser.id]);
+      await API.removeUser(groups[index].id, loggedInUser.id);
       // Updating groups
       removeCurGroup();
       notification.success({

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -141,10 +141,12 @@ function MainPage() {
     groups.forEach(group => {
       const { creator } = group;
 
-      // eslint-disable-next-line
-      group.creator.id = creator[0]._id;
-      // eslint-disable-next-line prefer-destructuring, no-param-reassign
-      group.creator = creator[0];
+      if (creator[0]) {
+        // eslint-disable-next-line no-param-reassign
+        group.creator.id = creator[0]._id;
+        // eslint-disable-next-line prefer-destructuring, no-param-reassign
+        group.creator = creator[0];
+      }
     });
 
     // Set the index to -1 if there are no groups to load so

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -170,9 +170,6 @@ function MainPage() {
     try {
       if (groups.length > 0) {
         const group = groups[index];
-
-        setGroupTitle(group.name);
-        setLoadingImages(true);
         /* eslint no-underscore-dangle: */
         setGroupTitle(group.name);
         setLoadingImages(true);
@@ -188,6 +185,13 @@ function MainPage() {
         groupDispatch({
           type: 'setImages',
           payload: images,
+        });
+      } else {
+        setGroupTitle('');
+        setIsOwner(false);
+        groupDispatch({
+          type: 'setImages',
+          payload: [],
         });
       }
     } catch (e) {
@@ -223,6 +227,7 @@ function MainPage() {
                         )}
                       </div>
                     </Skeleton>
+{/* NEED TO MAKE PHOTOGRID REVERT TO THE EMPTY SCREEN WHEN GROUP LIST IS SIZE 0 AFTER DELETION. */}
                     <PhotoGrid photos={groupData.images} />
                   </div>
                 </div>


### PR DESCRIPTION
Checks for if the creator array is empty for a group and fixes issue where photogrid and title does not update when leaving the last group in the group list for a user.