### PR TITLE
Adds ability to delete a group

### DIFF
--- a/src/api/API.js
+++ b/src/api/API.js
@@ -392,6 +392,22 @@ const API = {
       })
       .then(response => response.data);
   },
+
+  /**
+   * Deletes a group with the given id.
+   *
+   * @param {string} groupId
+   * @param {string} userId
+   */
+  async deleteGroup(groupId, userId) {
+    return axios
+      .delete(`/groups/${groupId}`, {
+        data: {
+          user: userId,
+        },
+      })
+      .then(response => response.data);
+  },
 };
 
 export { API as default, BASE_URL };

--- a/src/components/CreateGroupModal.jsx
+++ b/src/components/CreateGroupModal.jsx
@@ -192,6 +192,7 @@ function CreateGroupModal({ visible, onClose }) {
     >
       <p className="input-title">Group Name</p>
       <Input
+        onPressEnter={createGroup}
         onInput={event => setGroupName(event.target.value)}
         disabled={isLoading}
         autoFocus

--- a/src/components/dashboard/GroupMenuButton.jsx
+++ b/src/components/dashboard/GroupMenuButton.jsx
@@ -17,13 +17,14 @@ import API from '../../api/API';
 
 function GroupMenu({ className, isOwner }) {
   const [isInviteModalOpen, setInviteModalOpen] = useState(false);
-  const openInviteModal = () => setInviteModalOpen(true);
-  const closeInviteModal = () => setInviteModalOpen(false);
+  const [groupName, setGroupName] = useState('');
   const [loggedInUser, setLoggedInUser] = useState({});
   const { groups, index } = useContext(GroupsStateContext);
   const user = useContext(UserStateContext);
   const dispatch = useContext(GroupContextDispatch);
-  const [groupName, setGroupName] = useState('');
+
+  const openInviteModal = () => setInviteModalOpen(true);
+  const closeInviteModal = () => setInviteModalOpen(false);
 
   useEffect(() => {
     setLoggedInUser(user);

--- a/src/components/dashboard/GroupMenuButton.jsx
+++ b/src/components/dashboard/GroupMenuButton.jsx
@@ -89,10 +89,12 @@ function GroupMenu({ className, isOwner }) {
   const openDeleteGroupWarning = () => {
     Modal.confirm({
       title: 'Delete Group',
-      content: `
-        Are you sure you want to delete ${groupName}?
-        There's no going back!
-      `,
+      content: (
+        <span>
+          Are you sure you want to delete <b>{groupName}</b> There&apos;s no
+          going back!
+        </span>
+      ),
       cancelText: 'Cancel',
       okText: 'Delete Group',
       maskClosable: true,
@@ -103,7 +105,11 @@ function GroupMenu({ className, isOwner }) {
   const openLeaveGroupWarning = () => {
     Modal.confirm({
       title: 'Leave Group',
-      content: `Are you sure you want to leave ${groupName}?`,
+      content: (
+        <span>
+          Are you sure you want to leave <b>{groupName}</b>?
+        </span>
+      ),
       cancelText: 'Cancel',
       okText: 'Leave Group',
       maskClosable: true,

--- a/src/components/dashboard/JoinGroupButton.jsx
+++ b/src/components/dashboard/JoinGroupButton.jsx
@@ -126,6 +126,7 @@ function JoinGroupButton() {
         <form onSubmit={submitCode}>
           <p>Enter a group invite link or an invite code.</p>
           <Input
+            autoFocus
             className="group-code-input"
             onChange={event => setGroupCode(event.target.value)}
             value={groupCode}

--- a/src/components/dashboard/JoinGroupButton.jsx
+++ b/src/components/dashboard/JoinGroupButton.jsx
@@ -1,9 +1,5 @@
 import React, { useState, useContext } from 'react';
-import {
-  Modal,
-  Input,
-  notification,
-} from 'antd';
+import { Modal, Input, notification } from 'antd';
 import Button from '../Button.jsx';
 import '../../scss/join-group-button.scss';
 import API from '../../api/API';
@@ -14,18 +10,18 @@ import SocketContext from '../../contexts/SocketContext.jsx';
 function JoinGroupButton() {
   const [visible, setVisible] = useState(false);
   const [confirmLoading, setConfirmLoading] = useState(false);
-  const [input, setInput] = useState('');
+  const [groupCode, setGroupCode] = useState('');
   const dispatch = useContext(GroupContextDispatch);
   const { groups } = useContext(GroupsStateContext);
   const socket = useContext(SocketContext);
 
   function showModal() {
-    setInput('');
+    setGroupCode('');
     setVisible(true);
   }
 
   function handleCancel() {
-    setInput('');
+    setGroupCode('');
     setConfirmLoading(false);
     setVisible(false);
   }
@@ -39,7 +35,7 @@ function JoinGroupButton() {
 
   async function submitCode(event) {
     event.preventDefault();
-    let invite = input;
+    let invite = groupCode;
 
     if (confirmLoading === true) {
       return;
@@ -51,7 +47,7 @@ function JoinGroupButton() {
       // Extracting the invite code from url if given a url
       if (invite.length < 36) {
         // potential invite is empty or too short to be an actual invite code
-        throw (new Error('Code cannot be empty or is too short to be an invite code.'));
+        throw new Error('Invalid invite code');
       } else if (invite.length > 36) {
         // Need to parse invite code out
         invite = parseInvite(invite);
@@ -72,12 +68,31 @@ function JoinGroupButton() {
       // for incoming socket events.
       socket.emit('join', [group.id]);
     } catch (e) {
-      setConfirmLoading(false);
+      let message;
+
+      switch (e.status) {
+        case 418:
+          message = "You're already a member of this group.";
+          break;
+        case 403:
+        case 404:
+          message = 'The group you’re looking for doesn’t exist.';
+          break;
+        default:
+          message = 'An unknown error occurred, please try again.';
+      }
+
+      if (!e.status) {
+        message = e.message;
+      }
+
       notification.error({
         message: 'Error Joining Group',
-        description: e.message,
+        description: message,
         key: 'group-join-error',
       });
+
+      setConfirmLoading(false);
       return;
     }
 
@@ -85,31 +100,36 @@ function JoinGroupButton() {
       message: 'Joined Group',
       key: 'join-group-success',
     });
-    setInput('');
+
+    setGroupCode('');
     setVisible(false);
     setConfirmLoading(false);
   }
 
   return (
-    <div className='center'>
-      <Button className='joinButton' onClick={showModal}>Join Group</Button>
+    <div className="center">
+      <Button className="joinButton" onClick={showModal}>
+        Join Group
+      </Button>
       <Modal
         centered
-        title='Join group'
+        title="Join group"
         visible={visible}
         onOk={submitCode}
         confirmLoading={confirmLoading}
         onCancel={handleCancel}
-        okText='Join'
+        okButtonProps={{
+          disabled: confirmLoading || !groupCode.trim(),
+        }}
+        okText="Join"
       >
         <form onSubmit={submitCode}>
-            <p>Enter a group invite link or an invite code.</p>
-            <Input
-              className="group-code-input"
-              placeHolder='Example: xJwY394p'
-              onChange={event => setInput(event.target.value)}
-              value={input}
-            />
+          <p>Enter a group invite link or an invite code.</p>
+          <Input
+            className="group-code-input"
+            onChange={event => setGroupCode(event.target.value)}
+            value={groupCode}
+          />
         </form>
       </Modal>
     </div>

--- a/src/scss/ant-overrides.scss
+++ b/src/scss/ant-overrides.scss
@@ -51,8 +51,9 @@
 }
 
 // The title for ant's Alert component
+.ant-modal-confirm-title,
 .ant-alert-message {
-  font-weight: 600;
+  font-weight: 600 !important;
 }
 
 // The body of ant's Alert component

--- a/src/scss/password-reset-page.scss
+++ b/src/scss/password-reset-page.scss
@@ -25,7 +25,7 @@
   .reset-card {
     margin: 8px;
     border-radius: 8px;
-    padding: 32px;
+    padding: 22px 32px;
     display: flex;
     align-items: center;
     flex-direction: column;
@@ -51,7 +51,7 @@
     margin: 8px 0;
     width: 80%;
   }
-  
+
   .submit {
     margin-top: 10px;
   }

--- a/src/scss/password-reset-page.scss
+++ b/src/scss/password-reset-page.scss
@@ -44,6 +44,7 @@
 
   .card-text {
     text-align: center;
+    color: hsl(0, 0%, 45%);
   }
 
   .textbox {
@@ -68,5 +69,9 @@
 
   .password-checklist {
     margin: 8px 0;
+  }
+
+  .invalid-link-alert {
+    width: 100%;
   }
 }


### PR DESCRIPTION
Also adds a few small updates:

* The reset password button on the password reset page is disabled until the password meets the requirements
* An invalid link error is shown if `verificationCode` is missing from the URL
* In the create group modal, pressing enter now creates a group (this was disabled a few PRs ago because of a bug that caused the page to refresh)
* The text input in the join group modal is automatically focused when the modal opens

FIxes #139.