### PR TITLE
Map reducer dispatches to functions

### DIFF
--- a/src/actions/GroupActions.js
+++ b/src/actions/GroupActions.js
@@ -31,8 +31,8 @@ const GroupActions = {
           ...group,
           memberCount: 1,
         },
+        index,
       },
-      index,
     };
   },
 

--- a/src/actions/GroupActions.js
+++ b/src/actions/GroupActions.js
@@ -1,12 +1,28 @@
 const GroupActions = {
+  /**
+   * Sets the current selected group index.
+   *
+   * @param {number} index
+   */
   setIndex(index) {
     return { type: 'setIndex', payload: index };
   },
 
+  /**
+   * Sets the images currently viewed in the group.
+   *
+   * @param {*} images The images to be set to.
+   */
   setImages(images) {
     return { type: 'setImages', payload: images };
   },
 
+  /**
+   * Adds the group to existing list of groups.
+   *
+   * @param {*} group The group to be added.
+   * @param {number | undefined} index The index to update to.
+   */
   addGroup(group, index = undefined) {
     return {
       type: 'addGroup',
@@ -18,6 +34,12 @@ const GroupActions = {
     };
   },
 
+  /**
+   * Replaces the groups at the given index.
+   *
+   * @param {*} groups Groups to replace with.
+   * @param {number} index Index to replace at.
+   */
   replaceGroups(groups, index) {
     return {
       type: 'replaceGroups',
@@ -28,6 +50,11 @@ const GroupActions = {
     };
   },
 
+  /**
+   * Adds an image to the current group.
+   *
+   * @param {*} image The image to add.
+   */
   addImage(image) {
     return {
       type: 'addImage',
@@ -35,6 +62,13 @@ const GroupActions = {
     };
   },
 
+  /**
+   * Initializes the default values for the groups state.
+   *
+   * @param {*} groups The initial groups.
+   * @param {*} images The initial image.
+   * @param {number} index The initial index.
+   */
   init(groups, images, index) {
     return {
       type: 'init',
@@ -46,6 +80,11 @@ const GroupActions = {
     };
   },
 
+  /**
+   * Updates the group member count.
+   *
+   * @param {*} groups The current list of groups.
+   */
   updateGroupMemberCount(groups) {
     return { type: 'updateGroupMemberCount', payload: groups };
   },

--- a/src/actions/GroupActions.js
+++ b/src/actions/GroupActions.js
@@ -1,3 +1,6 @@
+/**
+ * Mapped actions for the groups state reducer.
+ */
 const GroupActions = {
   /**
    * Sets the current selected group index.

--- a/src/actions/GroupActions.js
+++ b/src/actions/GroupActions.js
@@ -1,0 +1,54 @@
+const GroupActions = {
+  setIndex(index) {
+    return { type: 'setIndex', payload: index };
+  },
+
+  setImages(images) {
+    return { type: 'setImages', payload: images };
+  },
+
+  addGroup(group, index = undefined) {
+    return {
+      type: 'addGroup',
+      payload: {
+        ...group,
+        memberCount: 1,
+      },
+      index,
+    };
+  },
+
+  replaceGroups(groups, index) {
+    return {
+      type: 'replaceGroups',
+      payload: {
+        groups,
+        index,
+      },
+    };
+  },
+
+  addImage(image) {
+    return {
+      type: 'addImage',
+      payload: image,
+    };
+  },
+
+  init(groups, images, index) {
+    return {
+      type: 'init',
+      payload: {
+        groups,
+        images,
+        index,
+      },
+    };
+  },
+
+  updateGroupMemberCount(groups) {
+    return { type: 'updateGroupMemberCount', payload: groups };
+  },
+};
+
+export default GroupActions;

--- a/src/actions/GroupActions.js
+++ b/src/actions/GroupActions.js
@@ -27,8 +27,10 @@ const GroupActions = {
     return {
       type: 'addGroup',
       payload: {
-        ...group,
-        memberCount: 1,
+        group: {
+          ...group,
+          memberCount: 1,
+        },
       },
       index,
     };

--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -1,0 +1,7 @@
+const UserActions = {
+  updateUser(user) {
+    return { type: 'updateUser', payload: user };
+  },
+};
+
+export default UserActions;

--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -1,4 +1,9 @@
 const UserActions = {
+  /**
+   * Updates the currently used user.
+   *
+   * @param {*} user The user to update to.
+   */
   updateUser(user) {
     return { type: 'updateUser', payload: user };
   },

--- a/src/actions/UserActions.js
+++ b/src/actions/UserActions.js
@@ -1,3 +1,6 @@
+/**
+ * Mapped actions for the User state reducer.
+ */
 const UserActions = {
   /**
    * Updates the currently used user.

--- a/src/components/CreateGroupModal.jsx
+++ b/src/components/CreateGroupModal.jsx
@@ -16,6 +16,7 @@ import GroupsContextDispatch from '../contexts/GroupsContextDispatch.jsx';
 import API from '../api/API';
 import GroupsStateContext from '../contexts/GroupStateContext.jsx';
 import SocketContext from '../contexts/SocketContext.jsx';
+import GroupActions from '../actions/GroupActions';
 
 function CreateGroupModal({ visible, onClose }) {
   const [groupName, setGroupName] = useState('');
@@ -77,17 +78,7 @@ function CreateGroupModal({ visible, onClose }) {
       // Passing the length of the user's groups here so that the
       // currently selected group index  will always be the
       // newly created group index (essentially groups[groups.length - 1])
-      dispatch({
-        type: 'addGroup',
-        payload: {
-          group: {
-            ...group,
-            // TODO: Remove this. This should be handled by the server
-            memberCount: 1,
-          },
-          index: groups.length,
-        },
-      });
+      dispatch(GroupActions.addGroup(group, groups.length));
 
       socket.emit('join', [group.id]);
     } catch (err) {

--- a/src/components/EditAccountModal.jsx
+++ b/src/components/EditAccountModal.jsx
@@ -15,6 +15,7 @@ import UserStateContext from '../contexts/UserStateContext.jsx';
 import TextInput from './TextInput.jsx';
 import API from '../api/API';
 import UserContextDispatch from '../contexts/UserContextDispatch.jsx';
+import UserActions from '../actions/UserActions';
 
 // 5 megabytes
 const MAX_FILE_SIZE = 5e6;
@@ -189,10 +190,7 @@ function EditAccountModal({ visible, onClose }) {
         token: authToken,
       });
 
-      dispatch({
-        type: 'updateUser',
-        payload: userInfo,
-      });
+      dispatch(UserActions.updateUser(userInfo));
 
       notification.success({
         key: 'update-success',

--- a/src/components/ImageUploadModal.jsx
+++ b/src/components/ImageUploadModal.jsx
@@ -17,6 +17,7 @@ import GroupStateContext from '../contexts/GroupStateContext.jsx';
 import UserStateContext from '../contexts/UserStateContext.jsx';
 import GroupContextDispatch from '../contexts/GroupsContextDispatch.jsx';
 import API from '../api/API';
+import GroupActions from '../actions/GroupActions';
 
 // 2 megabytes
 const MAX_FILE_SIZE = 2e6;
@@ -168,10 +169,7 @@ function ImageUploadModal({ visible, onClose }) {
         cancelTokenSource.token,
       );
 
-      dispatch({
-        type: 'addImage',
-        payload: image,
-      });
+      dispatch(GroupActions.addImage(image));
 
       // Reset the state of the modal when the image finishes uploading
       setIsUploading(false);

--- a/src/components/dashboard/GroupMenuButton.jsx
+++ b/src/components/dashboard/GroupMenuButton.jsx
@@ -15,6 +15,7 @@ import UserStateContext from '../../contexts/UserStateContext.jsx';
 import GroupContextDispatch from '../../contexts/GroupsContextDispatch.jsx';
 import API from '../../api/API';
 import ImageUploadModal from '../ImageUploadModal.jsx';
+import GroupActions from '../../actions/GroupActions';
 
 function GroupMenu({ className, isOwner }) {
   const [isInviteModalOpen, setInviteModalOpen] = useState(false);
@@ -49,13 +50,7 @@ function GroupMenu({ className, isOwner }) {
     });
 
     // Setting new index to 0 for safety if groups list is not empty
-    dispatch({
-      type: 'replaceGroups',
-      payload: {
-        groups: newGroups,
-        index: newGroups.length === 0 ? -1 : 0,
-      },
-    });
+    dispatch(GroupActions.replaceGroups(newGroups, newGroups.length === 0 ? -1 : 0));
   };
 
   const deleteGroup = async () => {

--- a/src/components/dashboard/JoinGroupButton.jsx
+++ b/src/components/dashboard/JoinGroupButton.jsx
@@ -6,6 +6,7 @@ import API from '../../api/API';
 import GroupContextDispatch from '../../contexts/GroupsContextDispatch.jsx';
 import GroupsStateContext from '../../contexts/GroupStateContext.jsx';
 import SocketContext from '../../contexts/SocketContext.jsx';
+import GroupActions from '../../actions/GroupActions';
 
 function JoinGroupButton() {
   const [visible, setVisible] = useState(false);
@@ -56,13 +57,7 @@ function JoinGroupButton() {
       const id = localStorage.getItem('id');
       const group = await API.joinGroup(id, invite);
 
-      dispatch({
-        type: 'addGroup',
-        payload: {
-          group,
-          index: groups.length,
-        },
-      });
+      dispatch(GroupActions.addGroup(group, groups.length));
 
       // Need to join the room for this group so we can listen
       // for incoming socket events.

--- a/src/components/dashboard/PhotoThumbnail.jsx
+++ b/src/components/dashboard/PhotoThumbnail.jsx
@@ -16,6 +16,7 @@ import UserStateContext from '../../contexts/UserStateContext.jsx';
 import GroupStateContext from '../../contexts/GroupStateContext.jsx';
 import GroupsContextDispatch from '../../contexts/GroupsContextDispatch.jsx';
 import API from '../../api/API';
+import GroupActions from '../../actions/GroupActions';
 
 function PhotoThumbnail({
   // prettier-ignore
@@ -39,10 +40,7 @@ function PhotoThumbnail({
 
       await API.deleteImages(groupId, [imageId]);
 
-      dispatch({
-        type: 'setImages',
-        payload: images.filter(image => image.id !== imageId),
-      });
+      dispatch(GroupActions.setImages(images.filter(image => image.id !== imageId)));
 
       notification.success({
         key: 'image-deleted',

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -25,6 +25,8 @@ import UserContextDispatch, {
 } from '../contexts/UserContextDispatch.jsx';
 import LoadingContext from '../contexts/LoadingContext.jsx';
 import SocketContext from '../contexts/SocketContext.jsx';
+import GroupActions from '../actions/GroupActions';
+import UserActions from '../actions/UserActions';
 
 const socket = io(BASE_URL, {
   transports: ['websocket'],
@@ -135,10 +137,7 @@ function MainPage() {
     // currently viewing the group where the image was added or if the
     // person who uploaded the image is the current user
     if (groups[index].id === groupId && image.creator !== user.id) {
-      groupDispatch({
-        type: 'addImage',
-        payload: image,
-      });
+      groupDispatch(GroupActions.addImage(image));
 
       notification.info({
         key: 'image-upload-notification',
@@ -173,10 +172,7 @@ function MainPage() {
     }
 
     if (user.username !== username) {
-      groupDispatch({
-        type: 'updateGroupMemberCount',
-        payload: groups,
-      });
+      groupDispatch(GroupActions.updateGroupMemberCount(groups));
     }
   };
 
@@ -198,10 +194,7 @@ function MainPage() {
       setLoadingImages(false);
     }, 500);
 
-    groupDispatch({
-      type: 'setImages',
-      payload: images,
-    });
+    groupDispatch(GroupActions.setImages(images));
   };
 
   // Only want this to trigger once to grab user token and id.
@@ -217,10 +210,7 @@ function MainPage() {
       return;
     }
 
-    userDispatch({
-      type: 'updateUser',
-      payload: userInfo,
-    });
+    userDispatch(UserActions.updateUser(userInfo));
 
     const groups = await getGroups(id);
 
@@ -263,14 +253,7 @@ function MainPage() {
 
     // Set the index to -1 if there are no groups to load so
     // that it can be updated once the first new group is added
-    groupDispatch({
-      type: 'init',
-      payload: {
-        index: groups.length === 0 ? -1 : 0,
-        groups,
-        images,
-      },
-    });
+    groupDispatch(GroupActions.init(groups, images, groups.length === 0 ? -1 : 0));
   }, []);
 
   // We only want this to trigger when the selected group index changes.
@@ -283,10 +266,8 @@ function MainPage() {
     if (groups.length === 0) {
       setGroupTitle('');
       setIsGroupOwner(false);
-      groupDispatch({
-        type: 'setImages',
-        payload: [],
-      });
+
+      groupDispatch(GroupActions.setImages([]));
 
       return;
     }


### PR DESCRIPTION
Uses predefined functions instead of raw objects for dispatching actions:

Before:
```js
dispatch({
 type: 'updateUser',
 payload: userInfo
});
```

After:
```js
dispatch(UserActions.updateUser(userInfo));
```

Hopefully this helps with calling the functions and prevents wrong inputs being passed in.